### PR TITLE
Refactor alien interactions and quest pipeline

### DIFF
--- a/Assets/_Project/Scripts/Gameplay/Alien/Alien.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/Alien.cs
@@ -1,5 +1,6 @@
-using System;
+using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace Synaptik.Game
 {
@@ -9,16 +10,16 @@ namespace Synaptik.Game
         [SerializeField] private AlienDefinition _def;
         public AlienDefinition Definition => _def;
         [SerializeField] private float _receiveRadius = 1.3f;
-        [SerializeField] private DialogueBubble _dialogueBubblePrefab;
+        [FormerlySerializedAs("_dialogueBubblePrefab")]
+        [SerializeField] private DialogueBubble _dialogueBubble;
 
         public Emotion Emotion { get; private set; }
 
         private Animator _anim;
         private static readonly int EmotionHash = Animator.StringToHash("Emotion");
-        
-        
-        private int itemQuantity = 0;
-        public int ItemQuantity => itemQuantity;
+
+        private readonly Dictionary<string, AlienQuestRuntime> _questRuntimes = new Dictionary<string, AlienQuestRuntime>();
+        private readonly Dictionary<string, int> _receivedItemQuantities = new Dictionary<string, int>();
 
         private void Awake()
         {
@@ -30,27 +31,47 @@ namespace Synaptik.Game
             }
 
             Emotion = _def != null ? _def.StartEmotion : Emotion.Curious;
-            Debug.Log("Emotion at start: " + Emotion);
             ApplyAnimFromEmotion();
         }
 
         private void Start()
         {
-            AlienManager.Instance.RegisterAlien(this);
+            if (AlienManager.Instance != null)
+            {
+                AlienManager.Instance.RegisterAlien(this);
+            }
+
+            if (_def == null)
+            {
+                return;
+            }
+
             foreach (AlienQuest quest in _def.Quests)
             {
-                GameManager.Instance.RegisterMission(new Mission(quest.QuestId, quest.Title, quest.Description));
+                var hasQuestId = !string.IsNullOrWhiteSpace(quest.QuestId);
+
+                if (hasQuestId && quest.AutoRegisterMission && GameManager.Instance != null)
+                {
+                    GameManager.Instance.RegisterMission(new Mission(quest.QuestId, quest.Title, quest.Description));
+                }
+
+                if (quest.HasSteps && hasQuestId && !_questRuntimes.ContainsKey(quest.QuestId))
+                {
+                    _questRuntimes.Add(quest.QuestId, new AlienQuestRuntime(this, quest));
+                }
             }
         }
 
         private void OnDestroy()
         {
-            AlienManager.Instance.UnregisterAlien(this);
+            if (AlienManager.Instance != null)
+            {
+                AlienManager.Instance.UnregisterAlien(this);
+            }
         }
 
         private void ApplyAnimFromEmotion()
         {
-            return;
             if (_anim != null)
             {
                 _anim.SetInteger(EmotionHash, (int)Emotion);
@@ -61,73 +82,37 @@ namespace Synaptik.Game
         {
             if (_def == null || _def.Reactions == null)
             {
-                Debug.Log("No definition or reactions");
                 return;
             }
-            
-            if (_def.Reactions.TryFindRule(channel, playerEmotion, out var rule))
-            {
-                if (rule.SetNewEmotion)
-                {
-                    Emotion = rule.NewEmotion;
-                    ApplyAnimFromEmotion();
-                    Debug.Log(rule.NewEmotion);
-                }
 
-                if (_def.Dialogue != null && _def.Dialogue.TryGet(Emotion, channel, out var entry))
-                {
-                    _dialogueBubblePrefab.ShowFor(entry.EmojiLine, entry.Duration);
-                }
-                
-                MistrustManager.Instance.AddMistrust(rule.SuspicionDelta);
-                if (rule.QuestId != null)
-                {
-                    GameManager.Instance.SetMissionFinished(rule.QuestId);
-                }
-                
+            if (!_def.Reactions.TryFindRule(channel, playerEmotion, out var rule))
+            {
+                return;
             }
-            
+
+            HandleInteractionRule(rule, channel);
         }
 
         public bool TryReceiveItem(string itemId)
         {
             if (_def == null || _def.Reactions == null)
             {
-                Debug.Log("No definition or reactions");
                 return false;
             }
 
             if (!_def.Reactions.TryFindItemRule(itemId, out var rule))
             {
-                Debug.Log($"No rule for item {itemId}");
                 return false;
             }
-            
-            Debug.Log($"Rule found for item {itemId}: expected {rule.ExpectedItemId}, quantity {rule.ExpectedItemQuantity}, set if good {rule.SetIfGoodItem}, new emotion if good {rule.NewEmotionIfGoodItem}");
-            itemQuantity++;
-            if (itemQuantity >= rule.ExpectedItemQuantity)
+
+            var quantity = GetUpdatedItemQuantity(itemId);
+            if (quantity < rule.ExpectedItemQuantity)
             {
-                itemQuantity = 0;
-                if (rule.SetIfGoodItem)
-                {
-                    Emotion = rule.NewEmotionIfGoodItem;
-                    ApplyAnimFromEmotion();
-                    Debug.Log(rule.NewEmotionIfGoodItem);
-                }
-                
-                if (_def.Dialogue != null && _def.Dialogue.TryGet(itemId, out var entry)) // On reçoit un item, donc on utilise le channel Action forcémment (le joueur ne peut pas donner un objet en parlant)
-                {
-                    _dialogueBubblePrefab.ShowFor(entry.EmojiLine, entry.Duration);
-                    Debug.Log($"Dialogue for item {itemId}: {entry.EmojiLine}" );
-                }
-            
-                MistrustManager.Instance.AddMistrust(rule.SuspicionDelta);
-                if (rule.QuestId != null)
-                {
-                    GameManager.Instance.SetMissionFinished(rule.QuestId);
-                }
+                return true;
             }
-            
+
+            ResetItemQuantity(itemId);
+            HandleItemRule(rule, itemId);
             return true;
         }
 
@@ -141,6 +126,155 @@ namespace Synaptik.Game
         {
             Gizmos.color = Color.cyan;
             Gizmos.DrawWireSphere(transform.position, _receiveRadius);
+        }
+
+        internal void SetEmotion(Emotion newEmotion)
+        {
+            if (Emotion == newEmotion)
+            {
+                return;
+            }
+
+            Emotion = newEmotion;
+            ApplyAnimFromEmotion();
+        }
+
+        internal void ShowDialogue(string emojiLine, float duration)
+        {
+            if (_dialogueBubble == null || string.IsNullOrWhiteSpace(emojiLine) || duration <= 0f)
+            {
+                return;
+            }
+
+            _dialogueBubble.ShowFor(emojiLine, duration);
+        }
+
+        private void HandleInteractionRule(InterractionRule rule, Behavior channel)
+        {
+            var questResult = ProcessQuestStep(rule.QuestId, rule.QuestStepId);
+
+            if (!questResult.OverrideDefaultReaction)
+            {
+                if (rule.SetNewEmotion)
+                {
+                    SetEmotion(rule.NewEmotion);
+                }
+
+                TryShowDialogue(Emotion, channel);
+                ApplySuspicionDelta(rule.SuspicionDelta);
+            }
+
+            if (!questResult.Handled && !string.IsNullOrWhiteSpace(rule.QuestId))
+            {
+                GameManager.Instance?.SetMissionFinished(rule.QuestId);
+            }
+        }
+
+        private void HandleItemRule(ItemRule rule, string itemId)
+        {
+            var questResult = ProcessQuestStep(rule.QuestId, rule.QuestStepId);
+
+            if (!questResult.OverrideDefaultReaction)
+            {
+                if (rule.SetIfGoodItem)
+                {
+                    SetEmotion(rule.NewEmotionIfGoodItem);
+                }
+
+                TryShowItemDialogue(itemId);
+                ApplySuspicionDelta(rule.SuspicionDelta);
+            }
+
+            if (!questResult.Handled && !string.IsNullOrWhiteSpace(rule.QuestId))
+            {
+                GameManager.Instance?.SetMissionFinished(rule.QuestId);
+            }
+        }
+
+        private void TryShowDialogue(Emotion emotion, Behavior behavior)
+        {
+            if (_dialogueBubble == null || _def?.Dialogue == null)
+            {
+                return;
+            }
+
+            if (_def.Dialogue.TryGet(emotion, behavior, out var entry))
+            {
+                ShowDialogue(entry.EmojiLine, entry.Duration);
+            }
+        }
+
+        private void TryShowItemDialogue(string itemId)
+        {
+            if (_dialogueBubble == null || _def?.Dialogue == null)
+            {
+                return;
+            }
+
+            if (_def.Dialogue.TryGet(itemId, out var entry))
+            {
+                ShowDialogue(entry.EmojiLine, entry.Duration);
+            }
+        }
+
+        private void ApplySuspicionDelta(int delta)
+        {
+            if (delta == 0 || MistrustManager.Instance == null)
+            {
+                return;
+            }
+
+            if (delta > 0)
+            {
+                MistrustManager.Instance.AddMistrust(delta);
+            }
+            else
+            {
+                MistrustManager.Instance.RemoveMistrust(-delta);
+            }
+        }
+
+        private QuestStepRuntimeResult ProcessQuestStep(string questId, string questStepId)
+        {
+            if (string.IsNullOrWhiteSpace(questId) || string.IsNullOrWhiteSpace(questStepId))
+            {
+                return QuestStepRuntimeResult.NotHandled;
+            }
+
+            if (_questRuntimes.TryGetValue(questId, out var runtime))
+            {
+                return runtime.TryHandleStep(questStepId);
+            }
+
+            return QuestStepRuntimeResult.NotHandled;
+        }
+
+        private int GetUpdatedItemQuantity(string itemId)
+        {
+            if (string.IsNullOrEmpty(itemId))
+            {
+                return 0;
+            }
+
+            if (_receivedItemQuantities.TryGetValue(itemId, out var quantity))
+            {
+                quantity++;
+                _receivedItemQuantities[itemId] = quantity;
+                return quantity;
+            }
+
+            _receivedItemQuantities[itemId] = 1;
+            return 1;
+        }
+
+        private void ResetItemQuantity(string itemId)
+        {
+            if (string.IsNullOrEmpty(itemId))
+            {
+                return;
+            }
+
+            _receivedItemQuantities[itemId] = 0;
         }
     }
 }

--- a/Assets/_Project/Scripts/Gameplay/Alien/AlienQuest.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/AlienQuest.cs
@@ -1,9 +1,94 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
+using UnityEngine;
 
-[Serializable]
-public struct AlienQuest
+namespace Synaptik.Game
 {
-    public string QuestId;
-    public string Title;
-    public string Description;
+    [Serializable]
+    public struct AlienQuest
+    {
+        [SerializeField] private string _questId;
+        [SerializeField] private string _title;
+        [SerializeField, TextArea] private string _description;
+        [SerializeField] private bool _autoRegisterMission = true;
+        [SerializeField] private bool _autoCompleteMissionOnQuestEnd = true;
+        [SerializeField] private bool _enforceStepOrder = true;
+        [SerializeField] private bool _autoCompleteOnLastStep = true;
+        [SerializeField] private QuestStep[] _steps;
+
+        public string QuestId => _questId;
+        public string Title => _title;
+        public string Description => _description;
+        public bool AutoRegisterMission => _autoRegisterMission;
+        public bool AutoCompleteMissionOnQuestEnd => _autoCompleteMissionOnQuestEnd;
+        public bool EnforceStepOrder => _enforceStepOrder;
+        public bool AutoCompleteOnLastStep => _autoCompleteOnLastStep;
+        public IReadOnlyList<QuestStep> Steps => _steps ?? Array.Empty<QuestStep>();
+        public bool HasSteps => _steps != null && _steps.Length > 0;
+
+        public QuestStep GetStepAt(int index)
+        {
+            return _steps != null && index >= 0 && index < _steps.Length ? _steps[index] : default;
+        }
+    }
+
+    [Serializable]
+    public struct QuestStep
+    {
+        [SerializeField] private string _stepId;
+        [SerializeField] private string _displayName;
+        [SerializeField, TextArea] private string _description;
+        [SerializeField] private bool _allowMultipleTriggers;
+        [SerializeField] private bool _autoAdvanceToNext = true;
+        [SerializeField] private string _nextStepId;
+        [SerializeField] private bool _overrideDefaultReaction;
+        [SerializeField] private bool _completesQuest;
+        [SerializeField] private QuestAction[] _actions;
+
+        public string StepId => _stepId;
+        public string DisplayName => _displayName;
+        public string Description => _description;
+        public bool AllowMultipleTriggers => _allowMultipleTriggers;
+        public bool AutoAdvanceToNext => _autoAdvanceToNext;
+        public string NextStepId => _nextStepId;
+        public bool OverrideDefaultReaction => _overrideDefaultReaction;
+        public bool CompletesQuest => _completesQuest;
+        public IReadOnlyList<QuestAction> Actions => _actions ?? Array.Empty<QuestAction>();
+
+        public string ResolveStepId(int index)
+        {
+            return string.IsNullOrWhiteSpace(_stepId) ? $"step_{index}" : _stepId;
+        }
+    }
+
+    public enum QuestActionType
+    {
+        ChangeEmotion,
+        AdjustMistrust,
+        ShowDialogue,
+        RegisterMission,
+        CompleteMission
+    }
+
+    [Serializable]
+    public struct QuestAction
+    {
+        [SerializeField] private QuestActionType _actionType;
+        [SerializeField] private Emotion _emotion;
+        [SerializeField] private int _intValue;
+        [SerializeField] private string _missionId;
+        [SerializeField] private string _missionTitle;
+        [SerializeField, TextArea] private string _missionDescription;
+        [SerializeField, TextArea] private string _dialogueLine;
+        [SerializeField] private float _dialogueDuration;
+
+        public QuestActionType ActionType => _actionType;
+        public Emotion EmotionValue => _emotion;
+        public int IntValue => _intValue;
+        public string MissionId => _missionId;
+        public string MissionTitle => _missionTitle;
+        public string MissionDescription => _missionDescription;
+        public string DialogueLine => _dialogueLine;
+        public float DialogueDuration => _dialogueDuration <= 0f ? 2f : _dialogueDuration;
+    }
 }

--- a/Assets/_Project/Scripts/Gameplay/Alien/AlienQuest.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/AlienQuest.cs
@@ -10,8 +10,8 @@ namespace Synaptik.Game
         [SerializeField] private string _questId;
         [SerializeField] private string _title;
         [SerializeField, TextArea] private string _description;
-        [SerializeField] private bool _autoRegisterMission = true;
-        [SerializeField] private bool _autoCompleteMissionOnQuestEnd = true;
+        [SerializeField] private bool _autoRegisterMission;
+        [SerializeField] private bool _autoCompleteMissionOnQuestEnd;
         [SerializeField] private QuestStep[] _steps;
 
         public string QuestId => _questId;

--- a/Assets/_Project/Scripts/Gameplay/Alien/AlienQuest.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/AlienQuest.cs
@@ -12,8 +12,6 @@ namespace Synaptik.Game
         [SerializeField, TextArea] private string _description;
         [SerializeField] private bool _autoRegisterMission = true;
         [SerializeField] private bool _autoCompleteMissionOnQuestEnd = true;
-        [SerializeField] private bool _enforceStepOrder = true;
-        [SerializeField] private bool _autoCompleteOnLastStep = true;
         [SerializeField] private QuestStep[] _steps;
 
         public string QuestId => _questId;
@@ -21,8 +19,6 @@ namespace Synaptik.Game
         public string Description => _description;
         public bool AutoRegisterMission => _autoRegisterMission;
         public bool AutoCompleteMissionOnQuestEnd => _autoCompleteMissionOnQuestEnd;
-        public bool EnforceStepOrder => _enforceStepOrder;
-        public bool AutoCompleteOnLastStep => _autoCompleteOnLastStep;
         public IReadOnlyList<QuestStep> Steps => _steps ?? Array.Empty<QuestStep>();
         public bool HasSteps => _steps != null && _steps.Length > 0;
 
@@ -36,24 +32,14 @@ namespace Synaptik.Game
     public struct QuestStep
     {
         [SerializeField] private string _stepId;
-        [SerializeField] private string _displayName;
-        [SerializeField, TextArea] private string _description;
-        [SerializeField] private bool _allowMultipleTriggers;
-        [SerializeField] private bool _autoAdvanceToNext = true;
-        [SerializeField] private string _nextStepId;
-        [SerializeField] private bool _overrideDefaultReaction;
+        [SerializeField] private QuestStepType _stepType;
         [SerializeField] private bool _completesQuest;
-        [SerializeField] private QuestAction[] _actions;
+        [SerializeField] private string _nextStepId;
 
         public string StepId => _stepId;
-        public string DisplayName => _displayName;
-        public string Description => _description;
-        public bool AllowMultipleTriggers => _allowMultipleTriggers;
-        public bool AutoAdvanceToNext => _autoAdvanceToNext;
-        public string NextStepId => _nextStepId;
-        public bool OverrideDefaultReaction => _overrideDefaultReaction;
+        public QuestStepType StepType => _stepType;
         public bool CompletesQuest => _completesQuest;
-        public IReadOnlyList<QuestAction> Actions => _actions ?? Array.Empty<QuestAction>();
+        public string NextStepId => _nextStepId;
 
         public string ResolveStepId(int index)
         {
@@ -61,34 +47,9 @@ namespace Synaptik.Game
         }
     }
 
-    public enum QuestActionType
+    public enum QuestStepType
     {
-        ChangeEmotion,
-        AdjustMistrust,
-        ShowDialogue,
-        RegisterMission,
-        CompleteMission
-    }
-
-    [Serializable]
-    public struct QuestAction
-    {
-        [SerializeField] private QuestActionType _actionType;
-        [SerializeField] private Emotion _emotion;
-        [SerializeField] private int _intValue;
-        [SerializeField] private string _missionId;
-        [SerializeField] private string _missionTitle;
-        [SerializeField, TextArea] private string _missionDescription;
-        [SerializeField, TextArea] private string _dialogueLine;
-        [SerializeField] private float _dialogueDuration;
-
-        public QuestActionType ActionType => _actionType;
-        public Emotion EmotionValue => _emotion;
-        public int IntValue => _intValue;
-        public string MissionId => _missionId;
-        public string MissionTitle => _missionTitle;
-        public string MissionDescription => _missionDescription;
-        public string DialogueLine => _dialogueLine;
-        public float DialogueDuration => _dialogueDuration <= 0f ? 2f : _dialogueDuration;
+        Talk = 0,
+        GiveItem = 1
     }
 }

--- a/Assets/_Project/Scripts/Gameplay/Alien/AlienQuestRuntime.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/AlienQuestRuntime.cs
@@ -1,49 +1,28 @@
-using System;
 using System.Collections.Generic;
 using UnityEngine;
 
 namespace Synaptik.Game
 {
-    public readonly struct QuestStepRuntimeResult
-    {
-        public static readonly QuestStepRuntimeResult NotHandled = new QuestStepRuntimeResult(false, false);
-
-        public QuestStepRuntimeResult(bool handled, bool overrideDefaultReaction)
-        {
-            Handled = handled;
-            OverrideDefaultReaction = overrideDefaultReaction;
-        }
-
-        public bool Handled { get; }
-        public bool OverrideDefaultReaction { get; }
-    }
-
     public sealed class AlienQuestRuntime
     {
-        private readonly Alien _owner;
         private readonly AlienQuest _definition;
         private readonly QuestStep[] _steps;
-        private readonly string[] _stepIds;
         private readonly Dictionary<string, int> _stepIndexById;
-        private readonly HashSet<string> _completedSteps = new HashSet<string>();
         private int _currentIndex;
         private bool _questCompleted;
 
-        public AlienQuestRuntime(Alien owner, AlienQuest definition)
+        public AlienQuestRuntime(AlienQuest definition)
         {
-            _owner = owner;
             _definition = definition;
 
             var steps = definition.Steps;
             _steps = new QuestStep[steps.Count];
-            _stepIds = new string[steps.Count];
             _stepIndexById = new Dictionary<string, int>(steps.Count);
 
             for (int i = 0; i < steps.Count; i++)
             {
                 _steps[i] = steps[i];
                 var runtimeId = steps[i].ResolveStepId(i);
-                _stepIds[i] = runtimeId;
 
                 if (!_stepIndexById.ContainsKey(runtimeId))
                 {
@@ -58,117 +37,48 @@ namespace Synaptik.Game
             _currentIndex = 0;
         }
 
-        public QuestStepRuntimeResult TryHandleStep(string stepId)
+        public bool TryHandleStep(string stepId, QuestStepType triggerType)
         {
             if (!_definition.HasSteps || string.IsNullOrEmpty(stepId) || _questCompleted)
             {
-                return QuestStepRuntimeResult.NotHandled;
+                return false;
             }
 
             if (!_stepIndexById.TryGetValue(stepId, out var index))
             {
-                return QuestStepRuntimeResult.NotHandled;
+                return false;
             }
 
-            var runtimeId = _stepIds[index];
-            if (!_steps[index].AllowMultipleTriggers && _completedSteps.Contains(runtimeId))
+            if (index < 0 || index >= _steps.Length)
             {
-                return QuestStepRuntimeResult.NotHandled;
+                return false;
             }
 
-            if (_definition.EnforceStepOrder && index != _currentIndex)
+            if (_steps[index].StepType != triggerType)
             {
-                return QuestStepRuntimeResult.NotHandled;
+                return false;
+            }
+
+            if (index != _currentIndex)
+            {
+                return false;
             }
 
             ExecuteStep(index);
-
-            return new QuestStepRuntimeResult(true, _steps[index].OverrideDefaultReaction);
+            return true;
         }
 
         private void ExecuteStep(int index)
         {
             var step = _steps[index];
-            var runtimeId = _stepIds[index];
-
-            foreach (var action in step.Actions)
-            {
-                ExecuteAction(action);
-            }
-
-            if (!step.AllowMultipleTriggers)
-            {
-                _completedSteps.Add(runtimeId);
-            }
 
             if (step.CompletesQuest)
             {
                 CompleteQuest();
             }
-            else if (step.AutoAdvanceToNext)
+            else
             {
                 AdvanceToNext(index, step.NextStepId);
-            }
-        }
-
-        private void ExecuteAction(QuestAction action)
-        {
-            switch (action.ActionType)
-            {
-                case QuestActionType.ChangeEmotion:
-                    _owner.SetEmotion(action.EmotionValue);
-                    break;
-                case QuestActionType.AdjustMistrust:
-                    if (action.IntValue != 0 && MistrustManager.Instance != null)
-                    {
-                        if (action.IntValue >= 0)
-                        {
-                            MistrustManager.Instance.AddMistrust(action.IntValue);
-                        }
-                        else
-                        {
-                            MistrustManager.Instance.RemoveMistrust(-action.IntValue);
-                        }
-                    }
-                    break;
-                case QuestActionType.ShowDialogue:
-                    if (!string.IsNullOrWhiteSpace(action.DialogueLine))
-                    {
-                        _owner.ShowDialogue(action.DialogueLine, action.DialogueDuration);
-                    }
-                    break;
-                case QuestActionType.RegisterMission:
-                    RegisterMission(action);
-                    break;
-                case QuestActionType.CompleteMission:
-                    CompleteMission(action);
-                    break;
-            }
-        }
-
-        private void RegisterMission(QuestAction action)
-        {
-            if (GameManager.Instance == null || string.IsNullOrWhiteSpace(action.MissionId))
-            {
-                return;
-            }
-
-            var title = string.IsNullOrWhiteSpace(action.MissionTitle) ? action.MissionId : action.MissionTitle;
-            var description = action.MissionDescription;
-            GameManager.Instance.RegisterMission(new Mission(action.MissionId, title, description));
-        }
-
-        private void CompleteMission(QuestAction action)
-        {
-            if (GameManager.Instance == null)
-            {
-                return;
-            }
-
-            var missionId = string.IsNullOrWhiteSpace(action.MissionId) ? _definition.QuestId : action.MissionId;
-            if (!string.IsNullOrWhiteSpace(missionId))
-            {
-                GameManager.Instance.SetMissionFinished(missionId);
             }
         }
 
@@ -185,7 +95,7 @@ namespace Synaptik.Game
             {
                 _currentIndex = sequentialIndex;
             }
-            else if (_definition.AutoCompleteOnLastStep)
+            else
             {
                 CompleteQuest();
             }

--- a/Assets/_Project/Scripts/Gameplay/Alien/AlienQuestRuntime.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/AlienQuestRuntime.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Synaptik.Game
+{
+    public readonly struct QuestStepRuntimeResult
+    {
+        public static readonly QuestStepRuntimeResult NotHandled = new QuestStepRuntimeResult(false, false);
+
+        public QuestStepRuntimeResult(bool handled, bool overrideDefaultReaction)
+        {
+            Handled = handled;
+            OverrideDefaultReaction = overrideDefaultReaction;
+        }
+
+        public bool Handled { get; }
+        public bool OverrideDefaultReaction { get; }
+    }
+
+    public sealed class AlienQuestRuntime
+    {
+        private readonly Alien _owner;
+        private readonly AlienQuest _definition;
+        private readonly QuestStep[] _steps;
+        private readonly string[] _stepIds;
+        private readonly Dictionary<string, int> _stepIndexById;
+        private readonly HashSet<string> _completedSteps = new HashSet<string>();
+        private int _currentIndex;
+        private bool _questCompleted;
+
+        public AlienQuestRuntime(Alien owner, AlienQuest definition)
+        {
+            _owner = owner;
+            _definition = definition;
+
+            var steps = definition.Steps;
+            _steps = new QuestStep[steps.Count];
+            _stepIds = new string[steps.Count];
+            _stepIndexById = new Dictionary<string, int>(steps.Count);
+
+            for (int i = 0; i < steps.Count; i++)
+            {
+                _steps[i] = steps[i];
+                var runtimeId = steps[i].ResolveStepId(i);
+                _stepIds[i] = runtimeId;
+
+                if (!_stepIndexById.ContainsKey(runtimeId))
+                {
+                    _stepIndexById.Add(runtimeId, i);
+                }
+                else
+                {
+                    Debug.LogWarning($"Duplicate quest step id '{runtimeId}' detected for quest '{definition.QuestId}'. Only the first occurrence will be used.");
+                }
+            }
+
+            _currentIndex = 0;
+        }
+
+        public QuestStepRuntimeResult TryHandleStep(string stepId)
+        {
+            if (!_definition.HasSteps || string.IsNullOrEmpty(stepId) || _questCompleted)
+            {
+                return QuestStepRuntimeResult.NotHandled;
+            }
+
+            if (!_stepIndexById.TryGetValue(stepId, out var index))
+            {
+                return QuestStepRuntimeResult.NotHandled;
+            }
+
+            var runtimeId = _stepIds[index];
+            if (!_steps[index].AllowMultipleTriggers && _completedSteps.Contains(runtimeId))
+            {
+                return QuestStepRuntimeResult.NotHandled;
+            }
+
+            if (_definition.EnforceStepOrder && index != _currentIndex)
+            {
+                return QuestStepRuntimeResult.NotHandled;
+            }
+
+            ExecuteStep(index);
+
+            return new QuestStepRuntimeResult(true, _steps[index].OverrideDefaultReaction);
+        }
+
+        private void ExecuteStep(int index)
+        {
+            var step = _steps[index];
+            var runtimeId = _stepIds[index];
+
+            foreach (var action in step.Actions)
+            {
+                ExecuteAction(action);
+            }
+
+            if (!step.AllowMultipleTriggers)
+            {
+                _completedSteps.Add(runtimeId);
+            }
+
+            if (step.CompletesQuest)
+            {
+                CompleteQuest();
+            }
+            else if (step.AutoAdvanceToNext)
+            {
+                AdvanceToNext(index, step.NextStepId);
+            }
+        }
+
+        private void ExecuteAction(QuestAction action)
+        {
+            switch (action.ActionType)
+            {
+                case QuestActionType.ChangeEmotion:
+                    _owner.SetEmotion(action.EmotionValue);
+                    break;
+                case QuestActionType.AdjustMistrust:
+                    if (action.IntValue != 0 && MistrustManager.Instance != null)
+                    {
+                        if (action.IntValue >= 0)
+                        {
+                            MistrustManager.Instance.AddMistrust(action.IntValue);
+                        }
+                        else
+                        {
+                            MistrustManager.Instance.RemoveMistrust(-action.IntValue);
+                        }
+                    }
+                    break;
+                case QuestActionType.ShowDialogue:
+                    if (!string.IsNullOrWhiteSpace(action.DialogueLine))
+                    {
+                        _owner.ShowDialogue(action.DialogueLine, action.DialogueDuration);
+                    }
+                    break;
+                case QuestActionType.RegisterMission:
+                    RegisterMission(action);
+                    break;
+                case QuestActionType.CompleteMission:
+                    CompleteMission(action);
+                    break;
+            }
+        }
+
+        private void RegisterMission(QuestAction action)
+        {
+            if (GameManager.Instance == null || string.IsNullOrWhiteSpace(action.MissionId))
+            {
+                return;
+            }
+
+            var title = string.IsNullOrWhiteSpace(action.MissionTitle) ? action.MissionId : action.MissionTitle;
+            var description = action.MissionDescription;
+            GameManager.Instance.RegisterMission(new Mission(action.MissionId, title, description));
+        }
+
+        private void CompleteMission(QuestAction action)
+        {
+            if (GameManager.Instance == null)
+            {
+                return;
+            }
+
+            var missionId = string.IsNullOrWhiteSpace(action.MissionId) ? _definition.QuestId : action.MissionId;
+            if (!string.IsNullOrWhiteSpace(missionId))
+            {
+                GameManager.Instance.SetMissionFinished(missionId);
+            }
+        }
+
+        private void AdvanceToNext(int currentIndex, string nextStepId)
+        {
+            if (!string.IsNullOrEmpty(nextStepId) && _stepIndexById.TryGetValue(nextStepId, out var explicitIndex))
+            {
+                _currentIndex = explicitIndex;
+                return;
+            }
+
+            var sequentialIndex = currentIndex + 1;
+            if (sequentialIndex < _steps.Length)
+            {
+                _currentIndex = sequentialIndex;
+            }
+            else if (_definition.AutoCompleteOnLastStep)
+            {
+                CompleteQuest();
+            }
+        }
+
+        private void CompleteQuest()
+        {
+            if (_questCompleted)
+            {
+                return;
+            }
+
+            _questCompleted = true;
+
+            if (_definition.AutoCompleteMissionOnQuestEnd && GameManager.Instance != null && !string.IsNullOrWhiteSpace(_definition.QuestId))
+            {
+                GameManager.Instance.SetMissionFinished(_definition.QuestId);
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Gameplay/Alien/AlienQuestRuntime.cs.meta
+++ b/Assets/_Project/Scripts/Gameplay/Alien/AlienQuestRuntime.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 45fd8dca8a9098b409afe852d6ab1a77

--- a/Assets/_Project/Scripts/Gameplay/Alien/ReactionMatrix.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/ReactionMatrix.cs
@@ -1,51 +1,149 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Serialization;
 
-
-[CreateAssetMenu(menuName = "Synaptik/Alien/Reaction Matrix", fileName = "ReactionMatrix")]
-public class ReactionMatrix : ScriptableObject
+namespace Synaptik.Game
 {
-
-    [SerializeField] private InterractionRule[] _interrationRules = Array.Empty<InterractionRule>();
-    [SerializeField] private ItemRule[] _itemRules = Array.Empty<ItemRule>();
-    
-
-    public bool TryFindRule(Behavior channel, Emotion playerEmotion, out InterractionRule rule)
+    [CreateAssetMenu(menuName = "Synaptik/Alien/Reaction Matrix", fileName = "ReactionMatrix")]
+    public class ReactionMatrix : ScriptableObject
     {
-        var rules = _interrationRules;
-        for (int i = 0; i < rules.Length; i++)
+        [SerializeField, FormerlySerializedAs("_interrationRules")] private InterractionRule[] _interactionRules = Array.Empty<InterractionRule>();
+        [SerializeField] private ItemRule[] _itemRules = Array.Empty<ItemRule>();
+
+        private Dictionary<InteractionKey, InterractionRule> _interactionLookup;
+        private Dictionary<string, ItemRule> _itemLookup;
+        private int _cachedInteractionRuleCount;
+        private int _cachedItemRuleCount;
+
+        private void OnEnable()
         {
-            if (rules[i].Channel == channel && rules[i].PlayerEmotion == playerEmotion)
+            BuildLookups();
+        }
+
+        private void OnValidate()
+        {
+            BuildLookups();
+        }
+
+        public bool TryFindRule(Behavior channel, Emotion playerEmotion, out InterractionRule rule)
+        {
+            EnsureInteractionLookup();
+            return _interactionLookup.TryGetValue(new InteractionKey(channel, playerEmotion), out rule);
+        }
+
+        public bool TryFindItemRule(string itemId, out ItemRule rule)
+        {
+            EnsureItemLookup();
+            if (string.IsNullOrEmpty(itemId))
             {
-                rule = rules[i];
-                return true;
+                rule = default;
+                return false;
+            }
+
+            return _itemLookup.TryGetValue(itemId, out rule);
+        }
+
+        private void EnsureInteractionLookup()
+        {
+            if (_interactionLookup == null || _cachedInteractionRuleCount != _interactionRules.Length)
+            {
+                BuildInteractionLookup();
             }
         }
 
-        rule = default;
-        return false;
-    }
-
-    public bool TryFindItemRule(string itemId, out ItemRule rule)
-    {
-        if (string.IsNullOrEmpty(itemId))
+        private void EnsureItemLookup()
         {
-            rule = default;
-            return false;
-        }
-
-        var rules = _itemRules;
-        for (int i = 0; i < rules.Length; i++)
-        {
-            if (_itemRules[i].ExpectedItemId == itemId)
+            if (_itemLookup == null || _cachedItemRuleCount != _itemRules.Length)
             {
-                rule = rules[i];
-                return true;
+                BuildItemLookup();
             }
         }
 
-        rule = default;
-        return false;
+        private void BuildLookups()
+        {
+            BuildInteractionLookup();
+            BuildItemLookup();
+        }
+
+        private void BuildInteractionLookup()
+        {
+            var lookup = new Dictionary<InteractionKey, InterractionRule>(_interactionRules.Length);
+
+            for (int i = 0; i < _interactionRules.Length; i++)
+            {
+                var key = new InteractionKey(_interactionRules[i].Channel, _interactionRules[i].PlayerEmotion);
+                if (lookup.ContainsKey(key))
+                {
+                    Debug.LogWarning($"Duplicate interaction rule detected for {key}. Only the first occurrence will be used.");
+                    continue;
+                }
+
+                lookup.Add(key, _interactionRules[i]);
+            }
+
+            _interactionLookup = lookup;
+            _cachedInteractionRuleCount = _interactionRules.Length;
+        }
+
+        private void BuildItemLookup()
+        {
+            var lookup = new Dictionary<string, ItemRule>(StringComparer.OrdinalIgnoreCase);
+
+            for (int i = 0; i < _itemRules.Length; i++)
+            {
+                var expectedItemId = _itemRules[i].ExpectedItemId;
+                if (string.IsNullOrEmpty(expectedItemId))
+                {
+                    continue;
+                }
+
+                if (lookup.ContainsKey(expectedItemId))
+                {
+                    Debug.LogWarning($"Duplicate item rule detected for '{expectedItemId}'. Only the first occurrence will be used.");
+                    continue;
+                }
+
+                lookup.Add(expectedItemId, _itemRules[i]);
+            }
+
+            _itemLookup = lookup;
+            _cachedItemRuleCount = _itemRules.Length;
+        }
+
+        private readonly struct InteractionKey : IEquatable<InteractionKey>
+        {
+            private readonly Behavior _behavior;
+            private readonly Emotion _emotion;
+
+            public InteractionKey(Behavior behavior, Emotion emotion)
+            {
+                _behavior = behavior;
+                _emotion = emotion;
+            }
+
+            public bool Equals(InteractionKey other)
+            {
+                return _behavior == other._behavior && _emotion == other._emotion;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is InteractionKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return ((int)_behavior * 397) ^ (int)_emotion;
+                }
+            }
+
+            public override string ToString()
+            {
+                return $"{_behavior}/{_emotion}";
+            }
+        }
     }
 }

--- a/Assets/_Project/Scripts/Gameplay/Alien/Rule.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/Rule.cs
@@ -1,45 +1,47 @@
-﻿
-    using System;
-    using NaughtyAttributes;
-    using UnityEngine;
+using System;
+using NaughtyAttributes;
+using UnityEngine;
 
+namespace Synaptik.Game
+{
     [Serializable]
     public struct InterractionRule
     {
         [SerializeField] private Behavior _channel;
         [SerializeField] private Emotion _playerEmotion;
         [SerializeField] private string _questId;
- 
+        [SerializeField] private string _questStepId;
         [SerializeField] private int _suspicionDelta;
         [SerializeField] private bool _setNewEmotion;
         [SerializeField] private Emotion _newEmotion;
-        
 
         public Behavior Channel => _channel;
         public Emotion PlayerEmotion => _playerEmotion;
-        
         public string QuestId => _questId;
-
+        public string QuestStepId => _questStepId;
         public int SuspicionDelta => _suspicionDelta;
         public bool SetNewEmotion => _setNewEmotion;
         public Emotion NewEmotion => _newEmotion;
     }
-    
+
     [Serializable]
     public struct ItemRule
     {
         [Header("Item Reaction")]
         [SerializeField] private string _questId;
+        [SerializeField] private string _questStepId;
         [SerializeField] private string _expectedItemId;
         [SerializeField] private int _suspicionDelta;
         [SerializeField] private int _expectedItemQuantity;
         [SerializeField] private bool _setIfGoodItem;
         [SerializeField] private Emotion _newEmotionIfGoodItem;
-        
+
         public string QuestId => _questId;
+        public string QuestStepId => _questStepId;
         public string ExpectedItemId => _expectedItemId;
         public int SuspicionDelta => _suspicionDelta;
-        public int ExpectedItemQuantity => _expectedItemQuantity;
+        public int ExpectedItemQuantity => _expectedItemQuantity <= 0 ? 1 : _expectedItemQuantity;
         public bool SetIfGoodItem => _setIfGoodItem;
         public Emotion NewEmotionIfGoodItem => _newEmotionIfGoodItem;
     }
+}

--- a/Assets/_Project/Scripts/Gameplay/Alien/SO/Alien1/Alien1.asset
+++ b/Assets/_Project/Scripts/Gameplay/Alien/SO/Alien1/Alien1.asset
@@ -18,6 +18,21 @@ MonoBehaviour:
   _reactions: {fileID: 11400000, guid: 73d53233d08b9ba49be514744243debc, type: 2}
   _dialogue: {fileID: 11400000, guid: c610a60b133dc6d42b56d74c2e752b4e, type: 2}
   _quests:
-  - QuestId: Fleur
-    Title: Dinner romantique
-    Description: "Donner une fleur \xE0 l'alien curieux"
+  - _questId: Fleur
+    _title: Donner une fleur et parler
+    _description: oui oui oui oui oui
+    _autoRegisterMission: 1
+    _autoCompleteMissionOnQuestEnd: 0
+    _steps:
+    - _stepId: 0
+      _stepType: 0
+      _completesQuest: 0
+      _nextStepId: 1
+    - _stepId: 1
+      _stepType: 1
+      _completesQuest: 0
+      _nextStepId: 2
+    - _stepId: 2
+      _stepType: 0
+      _completesQuest: 1
+      _nextStepId: 0

--- a/Assets/_Project/Scripts/Gameplay/Alien/SO/ReactionMatrix.asset
+++ b/Assets/_Project/Scripts/Gameplay/Alien/SO/ReactionMatrix.asset
@@ -12,57 +12,66 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2663d4c0b200fdc4d9f43b6546dbdde5, type: 3}
   m_Name: ReactionMatrix
   m_EditorClassIdentifier: 
-  _interrationRules:
+  _interactionRules:
   - _channel: 1
     _playerEmotion: 1
     _questId: 
+    _questStepId: 
     _suspicionDelta: 15
     _setNewEmotion: 1
     _newEmotion: 1
   - _channel: 1
     _playerEmotion: 2
-    _questId: 
+    _questId: Fleur
+    _questStepId: 0
     _suspicionDelta: -10
     _setNewEmotion: 1
     _newEmotion: 2
   - _channel: 1
     _playerEmotion: 3
-    _questId: 
+    _questId: Fleur
+    _questStepId: 2
     _suspicionDelta: -5
     _setNewEmotion: 1
     _newEmotion: 3
   - _channel: 1
     _playerEmotion: 4
     _questId: 
+    _questStepId: 
     _suspicionDelta: 10
     _setNewEmotion: 1
     _newEmotion: 4
   - _channel: 2
     _playerEmotion: 4
     _questId: 
+    _questStepId: 
     _suspicionDelta: 10
     _setNewEmotion: 1
     _newEmotion: 4
   - _channel: 2
     _playerEmotion: 3
     _questId: 
+    _questStepId: 
     _suspicionDelta: -5
     _setNewEmotion: 1
     _newEmotion: 3
   - _channel: 2
     _playerEmotion: 2
     _questId: 
+    _questStepId: 
     _suspicionDelta: -10
     _setNewEmotion: 1
     _newEmotion: 2
   - _channel: 2
     _playerEmotion: 1
     _questId: 
+    _questStepId: 
     _suspicionDelta: 15
     _setNewEmotion: 1
     _newEmotion: 1
   _itemRules:
   - _questId: Fleur
+    _questStepId: 1
     _expectedItemId: Fleur
     _suspicionDelta: -10
     _expectedItemQuantity: 1

--- a/Assets/_Project/Scripts/Gameplay/GameManager.cs
+++ b/Assets/_Project/Scripts/Gameplay/GameManager.cs
@@ -76,9 +76,13 @@ public class GameManager : MonoBehaviour
             if (_missions[i].MissionID == missionName)
             {
                 var mission = _missions[i];
+                if (mission.IsFinished)
+                {
+                    return;
+                }
                 mission.IsFinished = true;
                 _missions[i] = mission;
-                
+
                 OnTaskEnd?.Invoke(mission);
 
                 Debug.Log($"Mission '{missionName}' terminée !");


### PR DESCRIPTION
## Summary
- reworked the alien controller to centralize dialogue, emotion, quest step and item handling
- introduced data-driven quest steps and runtime state to chain alien interactions dynamically
- optimized reaction lookups and added duplicate-mission guards in the game manager

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68e7a62151408330bfbdbe6359a06032