### PR TITLE
Add combo feedback bubble for player interactions

### DIFF
--- a/Assets/_Project/Scripts/Gameplay/Player/PlayerComboBubble.cs
+++ b/Assets/_Project/Scripts/Gameplay/Player/PlayerComboBubble.cs
@@ -1,0 +1,174 @@
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Synaptik.Game
+{
+    [DisallowMultipleComponent]
+    public class PlayerComboBubble : MonoBehaviour
+    {
+        [Header("Bubble Layout")]
+        [SerializeField] private float _verticalOffset = 2.6f;
+        [SerializeField] private Vector2 _bubbleSize = new Vector2(320f, 140f);
+        [SerializeField] private float _worldScale = 0.03f;
+        [SerializeField] private Color _backgroundColor = new Color(1f, 1f, 1f, 0.4f);
+        [SerializeField] private Color _textColor = Color.black;
+        [SerializeField] private TMP_FontAsset _fontAsset;
+        [SerializeField] private float _defaultLifetime = 1.75f;
+
+        private GameObject _bubbleRoot;
+        private RectTransform _bubbleRect;
+        private TextMeshProUGUI _label;
+        private float _remainingTime;
+        private Camera _camera;
+
+        private const float PanelPadding = 6f;
+        private const float TextPadding = 8f;
+
+        private void Awake()
+        {
+            EnsureHierarchy();
+            HideImmediate();
+        }
+
+        private void OnEnable()
+        {
+            if (_bubbleRoot != null)
+            {
+                _bubbleRoot.SetActive(false);
+            }
+        }
+
+        private void OnDisable()
+        {
+            HideImmediate();
+        }
+
+        private void LateUpdate()
+        {
+            if (_remainingTime <= 0f)
+            {
+                return;
+            }
+
+            _remainingTime -= Time.deltaTime;
+            if (_remainingTime <= 0f)
+            {
+                HideImmediate();
+                return;
+            }
+
+            UpdateLookAt();
+        }
+
+        public void Show(string text, float duration)
+        {
+            EnsureHierarchy();
+            if (_label == null)
+            {
+                return;
+            }
+
+            _label.text = text ?? string.Empty;
+            if (_bubbleRoot != null && !_bubbleRoot.activeSelf)
+            {
+                _bubbleRoot.SetActive(true);
+            }
+
+            _remainingTime = duration > 0f ? duration : _defaultLifetime;
+            UpdateLookAt();
+        }
+
+        public void HideImmediate()
+        {
+            _remainingTime = 0f;
+            if (_bubbleRoot != null)
+            {
+                _bubbleRoot.SetActive(false);
+            }
+        }
+
+        private void EnsureHierarchy()
+        {
+            if (_bubbleRoot != null && _label != null)
+            {
+                return;
+            }
+
+            _camera = Camera.main;
+
+            _bubbleRoot = new GameObject("PlayerComboBubble", typeof(RectTransform));
+            _bubbleRoot.transform.SetParent(transform, false);
+            _bubbleRect = (RectTransform)_bubbleRoot.transform;
+            _bubbleRect.localPosition = new Vector3(0f, _verticalOffset, 0f);
+            _bubbleRect.localScale = Vector3.one * Mathf.Max(0.0001f, _worldScale);
+            _bubbleRect.sizeDelta = _bubbleSize;
+            _bubbleRect.pivot = new Vector2(0.5f, 0f);
+
+            var canvas = _bubbleRoot.AddComponent<Canvas>();
+            canvas.renderMode = RenderMode.WorldSpace;
+            canvas.worldCamera = _camera;
+
+            var scaler = _bubbleRoot.AddComponent<CanvasScaler>();
+            scaler.dynamicPixelsPerUnit = 10f;
+
+            var panel = new GameObject("Panel", typeof(RectTransform), typeof(CanvasRenderer), typeof(Image));
+            panel.transform.SetParent(_bubbleRect, false);
+            var panelRect = (RectTransform)panel.transform;
+            panelRect.anchorMin = Vector2.zero;
+            panelRect.anchorMax = Vector2.one;
+            panelRect.offsetMin = new Vector2(PanelPadding, PanelPadding);
+            panelRect.offsetMax = new Vector2(-PanelPadding, -PanelPadding);
+
+            var panelImage = panel.GetComponent<Image>();
+            panelImage.color = _backgroundColor;
+            panelImage.raycastTarget = false;
+
+            var textObject = new GameObject("Text", typeof(RectTransform), typeof(CanvasRenderer));
+            textObject.transform.SetParent(panel.transform, false);
+            var textRect = (RectTransform)textObject.transform;
+            textRect.anchorMin = Vector2.zero;
+            textRect.anchorMax = Vector2.one;
+            textRect.offsetMin = new Vector2(TextPadding, TextPadding);
+            textRect.offsetMax = new Vector2(-TextPadding, -TextPadding);
+
+            _label = textObject.AddComponent<TextMeshProUGUI>();
+            if (_fontAsset != null)
+            {
+                _label.font = _fontAsset;
+            }
+            else if (TMP_Settings.defaultFontAsset != null)
+            {
+                _label.font = TMP_Settings.defaultFontAsset;
+            }
+
+            _label.color = _textColor;
+            _label.alignment = TextAlignmentOptions.Center;
+            _label.enableWordWrapping = true;
+            _label.raycastTarget = false;
+            _label.text = string.Empty;
+        }
+
+        private void UpdateLookAt()
+        {
+            if (_bubbleRect == null)
+            {
+                return;
+            }
+
+            if (_camera == null)
+            {
+                _camera = Camera.main;
+            }
+
+            if (_camera == null)
+            {
+                return;
+            }
+
+            var forward = _camera.transform.rotation * Vector3.forward;
+            var up = _camera.transform.rotation * Vector3.up;
+            _bubbleRect.rotation = Quaternion.LookRotation(forward, up);
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Gameplay/Player/PlayerComboBubble.cs.meta
+++ b/Assets/_Project/Scripts/Gameplay/Player/PlayerComboBubble.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 74eea693354e43b0be0532c44d043ed4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Project/Scripts/Gameplay/Player/PlayerInterraction.cs
+++ b/Assets/_Project/Scripts/Gameplay/Player/PlayerInterraction.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Serialization;
 
@@ -6,7 +7,84 @@ namespace Synaptik.Game
 {
     public class PlayerInteraction : MonoBehaviour
     {
-        
+        [Serializable]
+        private struct ComboSymbolDefinition
+        {
+            public Emotion Emotion;
+            public Behavior Behavior;
+            public string Symbols;
+            public float Duration;
+
+            public ComboSymbolDefinition(Emotion emotion, Behavior behavior, string symbols, float duration)
+            {
+                Emotion = emotion;
+                Behavior = behavior;
+                Symbols = symbols;
+                Duration = duration;
+            }
+        }
+
+        private readonly struct ComboKey : IEquatable<ComboKey>
+        {
+            public readonly Emotion Emotion;
+            public readonly Behavior Behavior;
+
+            public ComboKey(Emotion emotion, Behavior behavior)
+            {
+                Emotion = emotion;
+                Behavior = behavior;
+            }
+
+            public bool Equals(ComboKey other)
+            {
+                return Emotion == other.Emotion && Behavior == other.Behavior;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is ComboKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    return ((int)Emotion * 397) ^ (int)Behavior;
+                }
+            }
+        }
+
+        private static readonly Dictionary<Emotion, string> DefaultEmotionSymbols = new()
+        {
+            { Emotion.Anger, "⚡" },
+            { Emotion.Friendly, "❤️" },
+            { Emotion.Curious, "❓" },
+            { Emotion.Fearful, "😱" }
+        };
+
+        private static readonly Dictionary<Behavior, string> DefaultBehaviorSymbols = new()
+        {
+            { Behavior.Talking, "💬" },
+            { Behavior.Action, "✋" }
+        };
+
+        [Header("Combo Feedback")]
+        [SerializeField] private float _defaultComboBubbleDuration = 1.75f;
+        [SerializeField] private ComboSymbolDefinition[] _comboSymbolDefinitions =
+        {
+            new ComboSymbolDefinition(Emotion.Anger,    Behavior.Talking, "💬⚡", 2f),
+            new ComboSymbolDefinition(Emotion.Friendly, Behavior.Talking, "💬❤️", 2f),
+            new ComboSymbolDefinition(Emotion.Curious,  Behavior.Talking, "💬❓", 2f),
+            new ComboSymbolDefinition(Emotion.Fearful,  Behavior.Talking, "💬😱", 2f),
+            new ComboSymbolDefinition(Emotion.Anger,    Behavior.Action,  "✋⚡", 1.75f),
+            new ComboSymbolDefinition(Emotion.Friendly, Behavior.Action,  "✋❤️", 1.75f),
+            new ComboSymbolDefinition(Emotion.Curious,  Behavior.Action,  "✋❓", 1.75f),
+            new ComboSymbolDefinition(Emotion.Fearful,  Behavior.Action,  "✋😱", 1.75f),
+        };
+
+        private readonly Dictionary<ComboKey, ComboSymbolDefinition> _comboLookup = new();
+        private PlayerComboBubble _comboBubble;
+
         [Header("Pickup/Drop Settings")]
         [SerializeField] private Transform _handSocket;         // vide placé dans la main
         [SerializeField] private float _pickupRadius = 1.2f;    // portée
@@ -22,6 +100,17 @@ namespace Synaptik.Game
         [SerializeField] private float _interactRadius = 2f;
         [SerializeField] private float _interactHalfFov = 45f;
         [SerializeField] private LayerMask _alienMask;
+
+        private void Awake()
+        {
+            _comboBubble = GetComponent<PlayerComboBubble>();
+            if (_comboBubble == null)
+            {
+                _comboBubble = gameObject.AddComponent<PlayerComboBubble>();
+            }
+
+            RebuildComboLookup();
+        }
 
         private void Start()
         {
@@ -44,8 +133,70 @@ namespace Synaptik.Game
             }
         }
 
+        private void OnValidate()
+        {
+            RebuildComboLookup();
+        }
+
+        private void RebuildComboLookup()
+        {
+            _comboLookup.Clear();
+            if (_comboSymbolDefinitions == null)
+            {
+                return;
+            }
+
+            foreach (var definition in _comboSymbolDefinitions)
+            {
+                if (definition.Behavior == Behavior.None || definition.Emotion == Emotion.None)
+                {
+                    continue;
+                }
+
+                var key = new ComboKey(definition.Emotion, definition.Behavior);
+                if (_comboLookup.ContainsKey(key))
+                {
+                    _comboLookup[key] = definition;
+                }
+                else
+                {
+                    _comboLookup.Add(key, definition);
+                }
+            }
+        }
+
+        private void ShowComboFeedback(Emotion emotion, Behavior behavior)
+        {
+            if (_comboBubble == null || emotion == Emotion.None || behavior == Behavior.None)
+            {
+                return;
+            }
+
+            if (_comboLookup.Count == 0)
+            {
+                RebuildComboLookup();
+            }
+
+            var key = new ComboKey(emotion, behavior);
+            if (_comboLookup.TryGetValue(key, out var definition) && !string.IsNullOrWhiteSpace(definition.Symbols))
+            {
+                var duration = definition.Duration > 0f ? definition.Duration : _defaultComboBubbleDuration;
+                _comboBubble.Show(definition.Symbols, duration);
+                return;
+            }
+
+            if (!DefaultBehaviorSymbols.TryGetValue(behavior, out var behaviorSymbol) ||
+                !DefaultEmotionSymbols.TryGetValue(emotion, out var emotionSymbol))
+            {
+                return;
+            }
+
+            _comboBubble.Show(behaviorSymbol + emotionSymbol, _defaultComboBubbleDuration);
+        }
+
         private void HandleEmotionAction(Emotion emotion, Behavior behavior)
         {
+            ShowComboFeedback(emotion, behavior);
             Debug.Log($"HandleEmotionAction: {emotion} + {behavior}");
             Transform origin = _aimZone != null ? _aimZone : transform;
             Alien alien = TargetingUtil.FindAlienInFront(origin, _interactRadius, _interactHalfFov, _alienMask);


### PR DESCRIPTION
## Summary
- add a runtime-created player combo bubble to display feedback above the character
- show symbol sequences for each emotion/action combo even when interactions miss targets

## Testing
- not run (Unity editor only)


------
https://chatgpt.com/codex/tasks/task_e_68e7c95fd5b083309c1f68e6b0bdd115