### PR TITLE
Handle quest-aware alien dialogue selection

### DIFF
--- a/Assets/_Project/Scripts/Gameplay/Alien/Alien.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/Alien.cs
@@ -85,7 +85,7 @@ namespace Synaptik.Game
                 return;
             }
 
-            if (!_def.Reactions.TryFindRule(channel, playerEmotion, out var rule))
+            if (!_def.Reactions.TryFindRule(channel, playerEmotion, IsInteractionRuleAvailable, out var rule))
             {
                 return;
             }
@@ -167,6 +167,16 @@ namespace Synaptik.Game
             }
         }
 
+        private bool IsInteractionRuleAvailable(InterractionRule rule)
+        {
+            if (string.IsNullOrWhiteSpace(rule.QuestId) || string.IsNullOrWhiteSpace(rule.QuestStepId))
+            {
+                return true;
+            }
+
+            return IsQuestStepActive(rule.QuestId, rule.QuestStepId, QuestStepType.Talk);
+        }
+
         private void HandleItemRule(ItemRule rule, string itemId)
         {
             var handled = ProcessQuestStep(rule.QuestId, rule.QuestStepId, QuestStepType.GiveItem);
@@ -238,6 +248,21 @@ namespace Synaptik.Game
             if (_questRuntimes.TryGetValue(questId, out var runtime))
             {
                 return runtime.TryHandleStep(questStepId, triggerType);
+            }
+
+            return false;
+        }
+
+        private bool IsQuestStepActive(string questId, string questStepId, QuestStepType triggerType)
+        {
+            if (string.IsNullOrWhiteSpace(questId) || string.IsNullOrWhiteSpace(questStepId))
+            {
+                return false;
+            }
+
+            if (_questRuntimes.TryGetValue(questId, out var runtime))
+            {
+                return runtime.IsStepActive(questStepId, triggerType);
             }
 
             return false;

--- a/Assets/_Project/Scripts/Gameplay/Alien/AlienQuestRuntime.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/AlienQuestRuntime.cs
@@ -68,6 +68,31 @@ namespace Synaptik.Game
             return true;
         }
 
+        public bool IsStepActive(string stepId, QuestStepType triggerType)
+        {
+            if (!_definition.HasSteps || string.IsNullOrEmpty(stepId) || _questCompleted)
+            {
+                return false;
+            }
+
+            if (!_stepIndexById.TryGetValue(stepId, out var index))
+            {
+                return false;
+            }
+
+            if (index < 0 || index >= _steps.Length)
+            {
+                return false;
+            }
+
+            if (_steps[index].StepType != triggerType)
+            {
+                return false;
+            }
+
+            return index == _currentIndex;
+        }
+
         private void ExecuteStep(int index)
         {
             var step = _steps[index];


### PR DESCRIPTION
## Summary
- update the reaction matrix cache to keep all interaction rules per behavior/emotion pair and rebuild when edited
- expose quest runtime state so aliens can check whether a quest step is currently active
- filter interaction rules before handling them so aliens only respond with the dialogue for the active quest step

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68e8f3a39f3c8330b4d462b864fc3ef6