### PR TITLE
Fix dialogue display and quest progression logic

### DIFF
--- a/Assets/_Project/Scenes/Test_Shahine.unity
+++ b/Assets/_Project/Scenes/Test_Shahine.unity
@@ -1530,6 +1530,81 @@ RectTransform:
   m_AnchoredPosition: {x: -0.036102295, y: 0}
   m_SizeDelta: {x: -10.0723, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1037807577
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1037807578}
+  - component: {fileID: 1037807580}
+  - component: {fileID: 1037807579}
+  m_Layer: 5
+  m_Name: RightOutput
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1037807578
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1037807577}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2066461957}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 10, y: 40}
+  m_Pivot: {x: 0.5, y: 1.0000001}
+--- !u!114 &1037807579
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1037807577}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1037807580
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1037807577}
+  m_CullTransparentMesh: 1
 --- !u!1 &1150179969
 GameObject:
   m_ObjectHideFlags: 0
@@ -2614,7 +2689,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2006503671}
-  - {fileID: 1414251877}
+  - {fileID: 1037807578}
   m_Father: {fileID: 486928716}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
@@ -2635,7 +2710,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _outputLeft: {fileID: 2006503672}
-  _outputRight: {fileID: 1414251878}
+  _outputRight: {fileID: 0}
   _defaultActionColor: {r: 0, g: 0, b: 0, a: 1}
   _talkColor: {r: 1, g: 1, b: 1, a: 1}
   _actionColor: {r: 0.31024948, g: 0.18128152, b: 0.78113204, a: 1}

--- a/Assets/_Project/Scripts/Gameplay/Alien/Alien.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/Alien.cs
@@ -25,6 +25,20 @@ namespace Synaptik.Game
         {
             _anim = GetComponent<Animator>();
 
+            if (_dialogueBubble == null)
+            {
+                _dialogueBubble = GetComponentInChildren<DialogueBubble>(true);
+            }
+
+            if (_dialogueBubble != null && !_dialogueBubble.gameObject.scene.IsValid())
+            {
+                var prefabBubble = _dialogueBubble;
+                _dialogueBubble = Instantiate(prefabBubble, transform);
+                _dialogueBubble.transform.localPosition = prefabBubble.transform.localPosition;
+                _dialogueBubble.transform.localRotation = prefabBubble.transform.localRotation;
+                _dialogueBubble.transform.localScale = prefabBubble.transform.localScale;
+            }
+
             if (_def != null && _def.Animator != null)
             {
                 _anim.runtimeAnimatorController = _def.Animator;
@@ -220,7 +234,7 @@ namespace Synaptik.Game
 
         private bool IsInteractionRuleAvailable(InterractionRule rule)
         {
-            if (string.IsNullOrWhiteSpace(rule.QuestId) || string.IsNullOrWhiteSpace(rule.QuestStepId))
+            if (string.IsNullOrWhiteSpace(rule.QuestId))
             {
                 return true;
             }
@@ -291,7 +305,7 @@ namespace Synaptik.Game
 
         private bool ProcessQuestStep(string questId, string questStepId, QuestStepType triggerType)
         {
-            if (string.IsNullOrWhiteSpace(questId) || string.IsNullOrWhiteSpace(questStepId))
+            if (string.IsNullOrWhiteSpace(questId))
             {
                 return false;
             }
@@ -306,7 +320,7 @@ namespace Synaptik.Game
 
         private bool IsQuestStepActive(string questId, string questStepId, QuestStepType triggerType)
         {
-            if (string.IsNullOrWhiteSpace(questId) || string.IsNullOrWhiteSpace(questStepId))
+            if (string.IsNullOrWhiteSpace(questId))
             {
                 return false;
             }

--- a/Assets/_Project/Scripts/Gameplay/Alien/AlienQuest.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/AlienQuest.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 namespace Synaptik.Game
 {
     [Serializable]
-    public struct AlienQuest
+    public struct AlienQuest : IEquatable<AlienQuest>
     {
         [SerializeField] private string _questId;
         [SerializeField] private string _title;
@@ -25,6 +25,26 @@ namespace Synaptik.Game
         public QuestStep GetStepAt(int index)
         {
             return _steps != null && index >= 0 && index < _steps.Length ? _steps[index] : default;
+        }
+
+        public bool Equals(AlienQuest other)
+        {
+            return _questId == other._questId &&
+                   _title == other._title && 
+                   _description == other._description && 
+                   _autoRegisterMission == other._autoRegisterMission && 
+                   _autoCompleteMissionOnQuestEnd == other._autoCompleteMissionOnQuestEnd && 
+                   Equals(_steps, other._steps);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is AlienQuest other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(_questId, _title, _description, _autoRegisterMission, _autoCompleteMissionOnQuestEnd, _steps);
         }
     }
 

--- a/Assets/_Project/Scripts/Gameplay/Alien/AlienQuestRuntime.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/AlienQuestRuntime.cs
@@ -39,33 +39,42 @@ namespace Synaptik.Game
 
         public bool TryHandleStep(string stepId, QuestStepType triggerType)
         {
+            var questId = _definition != null ? _definition.QuestId : "<unknown>";
+            Debug.Log($"[QuestRuntime:{questId}] TryHandleStep trigger={triggerType} step='{stepId ?? "<current>"}' currentIndex={_currentIndex} completed={_questCompleted}");
+
             if (!_definition.HasSteps || _questCompleted)
             {
+                Debug.Log($"[QuestRuntime:{questId}] Ignored trigger because quest has no steps or already completed.");
                 return false;
             }
 
             if (string.IsNullOrEmpty(stepId))
             {
+                Debug.Log($"[QuestRuntime:{questId}] No step id provided. Using current step.");
                 return TryHandleCurrentStep(triggerType);
             }
 
             if (!_stepIndexById.TryGetValue(stepId, out var index))
             {
+                Debug.LogWarning($"[QuestRuntime:{questId}] Step id '{stepId}' not found.");
                 return false;
             }
 
             if (index < 0 || index >= _steps.Length)
             {
+                Debug.LogWarning($"[QuestRuntime:{questId}] Step index {index} is out of range.");
                 return false;
             }
 
             if (_steps[index].StepType != triggerType)
             {
+                Debug.Log($"[QuestRuntime:{questId}] Step '{stepId}' expects {_steps[index].StepType} but received {triggerType}.");
                 return false;
             }
 
             if (index != _currentIndex)
             {
+                Debug.Log($"[QuestRuntime:{questId}] Step '{stepId}' is not the current step (current index {_currentIndex}).");
                 return false;
             }
 
@@ -75,28 +84,36 @@ namespace Synaptik.Game
 
         public bool IsStepActive(string stepId, QuestStepType triggerType)
         {
+            var questId = _definition != null ? _definition.QuestId : "<unknown>";
+            Debug.Log($"[QuestRuntime:{questId}] IsStepActive trigger={triggerType} step='{stepId ?? "<current>"}' currentIndex={_currentIndex} completed={_questCompleted}");
+
             if (!_definition.HasSteps || _questCompleted)
             {
+                Debug.Log($"[QuestRuntime:{questId}] Quest has no steps or is completed. Returning inactive.");
                 return false;
             }
 
             if (string.IsNullOrEmpty(stepId))
             {
+                Debug.Log($"[QuestRuntime:{questId}] No step id provided. Checking current step only.");
                 return IsCurrentStepActive(triggerType);
             }
 
             if (!_stepIndexById.TryGetValue(stepId, out var index))
             {
+                Debug.LogWarning($"[QuestRuntime:{questId}] Step id '{stepId}' not found while checking activity.");
                 return false;
             }
 
             if (index < 0 || index >= _steps.Length)
             {
+                Debug.LogWarning($"[QuestRuntime:{questId}] Step index {index} out of range while checking activity.");
                 return false;
             }
 
             if (_steps[index].StepType != triggerType)
             {
+                Debug.Log($"[QuestRuntime:{questId}] Step '{stepId}' expects {_steps[index].StepType} but received {triggerType} while checking activity.");
                 return false;
             }
 
@@ -105,18 +122,24 @@ namespace Synaptik.Game
 
         public bool TryHandleCurrentStep(QuestStepType triggerType)
         {
+            var questId = _definition != null ? _definition.QuestId : "<unknown>";
+            Debug.Log($"[QuestRuntime:{questId}] TryHandleCurrentStep trigger={triggerType} currentIndex={_currentIndex} completed={_questCompleted}");
+
             if (!_definition.HasSteps || _questCompleted)
             {
+                Debug.Log($"[QuestRuntime:{questId}] Cannot handle current step because quest has no steps or already completed.");
                 return false;
             }
 
             if (_currentIndex < 0 || _currentIndex >= _steps.Length)
             {
+                Debug.LogWarning($"[QuestRuntime:{questId}] Current index {_currentIndex} out of range.");
                 return false;
             }
 
             if (_steps[_currentIndex].StepType != triggerType)
             {
+                Debug.Log($"[QuestRuntime:{questId}] Current step expects {_steps[_currentIndex].StepType} but received {triggerType}.");
                 return false;
             }
 
@@ -126,13 +149,18 @@ namespace Synaptik.Game
 
         public bool IsCurrentStepActive(QuestStepType triggerType)
         {
+            var questId = _definition != null ? _definition.QuestId : "<unknown>";
+            Debug.Log($"[QuestRuntime:{questId}] IsCurrentStepActive trigger={triggerType} currentIndex={_currentIndex} completed={_questCompleted}");
+
             if (!_definition.HasSteps || _questCompleted)
             {
+                Debug.Log($"[QuestRuntime:{questId}] Quest has no steps or already completed. Current step inactive.");
                 return false;
             }
 
             if (_currentIndex < 0 || _currentIndex >= _steps.Length)
             {
+                Debug.LogWarning($"[QuestRuntime:{questId}] Current index {_currentIndex} out of range while checking activity.");
                 return false;
             }
 
@@ -142,6 +170,9 @@ namespace Synaptik.Game
         private void ExecuteStep(int index)
         {
             var step = _steps[index];
+
+            var questId = _definition != null ? _definition.QuestId : "<unknown>";
+            Debug.Log($"[QuestRuntime:{questId}] Executing step index {index} completesQuest={step.CompletesQuest} nextStepId='{step.NextStepId}'.");
 
             if (step.CompletesQuest)
             {
@@ -155,8 +186,10 @@ namespace Synaptik.Game
 
         private void AdvanceToNext(int currentIndex, string nextStepId)
         {
+            var questId = _definition != null ? _definition.QuestId : "<unknown>";
             if (!string.IsNullOrEmpty(nextStepId) && _stepIndexById.TryGetValue(nextStepId, out var explicitIndex))
             {
+                Debug.Log($"[QuestRuntime:{questId}] Advancing to explicit step id '{nextStepId}' at index {explicitIndex}.");
                 _currentIndex = explicitIndex;
                 return;
             }
@@ -164,10 +197,12 @@ namespace Synaptik.Game
             var sequentialIndex = currentIndex + 1;
             if (sequentialIndex < _steps.Length)
             {
+                Debug.Log($"[QuestRuntime:{questId}] Advancing sequentially to index {sequentialIndex}.");
                 _currentIndex = sequentialIndex;
             }
             else
             {
+                Debug.Log($"[QuestRuntime:{questId}] No more steps. Completing quest.");
                 CompleteQuest();
             }
         }
@@ -176,10 +211,13 @@ namespace Synaptik.Game
         {
             if (_questCompleted)
             {
+                Debug.Log($"[QuestRuntime:{_definition?.QuestId ?? "<unknown>"}] CompleteQuest called but quest already completed.");
                 return;
             }
 
             _questCompleted = true;
+
+            Debug.Log($"[QuestRuntime:{_definition?.QuestId ?? "<unknown>"}] Quest completed.");
 
             if (_definition.AutoCompleteMissionOnQuestEnd && GameManager.Instance != null && !string.IsNullOrWhiteSpace(_definition.QuestId))
             {

--- a/Assets/_Project/Scripts/Gameplay/Alien/AlienQuestRuntime.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/AlienQuestRuntime.cs
@@ -39,7 +39,8 @@ namespace Synaptik.Game
 
         public bool TryHandleStep(string stepId, QuestStepType triggerType)
         {
-            var questId = _definition != null ? _definition.QuestId : "<unknown>";
+            
+            var questId = _definition.Equals(default(AlienQuest)) ? "<unknown>" : _definition.QuestId;
             Debug.Log($"[QuestRuntime:{questId}] TryHandleStep trigger={triggerType} step='{stepId ?? "<current>"}' currentIndex={_currentIndex} completed={_questCompleted}");
 
             if (!_definition.HasSteps || _questCompleted)
@@ -84,7 +85,7 @@ namespace Synaptik.Game
 
         public bool IsStepActive(string stepId, QuestStepType triggerType)
         {
-            var questId = _definition != null ? _definition.QuestId : "<unknown>";
+            var questId = _definition.Equals(default(AlienQuest)) ? "<unknown>" : _definition.QuestId;
             Debug.Log($"[QuestRuntime:{questId}] IsStepActive trigger={triggerType} step='{stepId ?? "<current>"}' currentIndex={_currentIndex} completed={_questCompleted}");
 
             if (!_definition.HasSteps || _questCompleted)
@@ -122,7 +123,7 @@ namespace Synaptik.Game
 
         public bool TryHandleCurrentStep(QuestStepType triggerType)
         {
-            var questId = _definition != null ? _definition.QuestId : "<unknown>";
+            var questId = _definition.Equals(default(AlienQuest)) ? "<unknown>" : _definition.QuestId;
             Debug.Log($"[QuestRuntime:{questId}] TryHandleCurrentStep trigger={triggerType} currentIndex={_currentIndex} completed={_questCompleted}");
 
             if (!_definition.HasSteps || _questCompleted)
@@ -149,7 +150,7 @@ namespace Synaptik.Game
 
         public bool IsCurrentStepActive(QuestStepType triggerType)
         {
-            var questId = _definition != null ? _definition.QuestId : "<unknown>";
+            var questId = _definition.Equals(default(AlienQuest)) ? "<unknown>" : _definition.QuestId;
             Debug.Log($"[QuestRuntime:{questId}] IsCurrentStepActive trigger={triggerType} currentIndex={_currentIndex} completed={_questCompleted}");
 
             if (!_definition.HasSteps || _questCompleted)
@@ -171,7 +172,7 @@ namespace Synaptik.Game
         {
             var step = _steps[index];
 
-            var questId = _definition != null ? _definition.QuestId : "<unknown>";
+            var questId = _definition.Equals(default(AlienQuest)) ? "<unknown>" : _definition.QuestId;
             Debug.Log($"[QuestRuntime:{questId}] Executing step index {index} completesQuest={step.CompletesQuest} nextStepId='{step.NextStepId}'.");
 
             if (step.CompletesQuest)
@@ -186,7 +187,7 @@ namespace Synaptik.Game
 
         private void AdvanceToNext(int currentIndex, string nextStepId)
         {
-            var questId = _definition != null ? _definition.QuestId : "<unknown>";
+            var questId = _definition.Equals(default(AlienQuest)) ? "<unknown>" : _definition.QuestId;
             if (!string.IsNullOrEmpty(nextStepId) && _stepIndexById.TryGetValue(nextStepId, out var explicitIndex))
             {
                 Debug.Log($"[QuestRuntime:{questId}] Advancing to explicit step id '{nextStepId}' at index {explicitIndex}.");
@@ -209,15 +210,17 @@ namespace Synaptik.Game
 
         private void CompleteQuest()
         {
+            var questId = _definition.Equals(default(AlienQuest)) ? "<unknown>" : _definition.QuestId;
+
             if (_questCompleted)
             {
-                Debug.Log($"[QuestRuntime:{_definition?.QuestId ?? "<unknown>"}] CompleteQuest called but quest already completed.");
+                Debug.Log($"[QuestRuntime:{questId}] CompleteQuest called but quest already completed.");
                 return;
             }
 
             _questCompleted = true;
 
-            Debug.Log($"[QuestRuntime:{_definition?.QuestId ?? "<unknown>"}] Quest completed.");
+            Debug.Log($"[QuestRuntime:{questId}] Quest completed.");
 
             if (_definition.AutoCompleteMissionOnQuestEnd && GameManager.Instance != null && !string.IsNullOrWhiteSpace(_definition.QuestId))
             {

--- a/Assets/_Project/Scripts/Gameplay/Alien/AlienQuestRuntime.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/AlienQuestRuntime.cs
@@ -39,9 +39,14 @@ namespace Synaptik.Game
 
         public bool TryHandleStep(string stepId, QuestStepType triggerType)
         {
-            if (!_definition.HasSteps || string.IsNullOrEmpty(stepId) || _questCompleted)
+            if (!_definition.HasSteps || _questCompleted)
             {
                 return false;
+            }
+
+            if (string.IsNullOrEmpty(stepId))
+            {
+                return TryHandleCurrentStep(triggerType);
             }
 
             if (!_stepIndexById.TryGetValue(stepId, out var index))
@@ -70,9 +75,14 @@ namespace Synaptik.Game
 
         public bool IsStepActive(string stepId, QuestStepType triggerType)
         {
-            if (!_definition.HasSteps || string.IsNullOrEmpty(stepId) || _questCompleted)
+            if (!_definition.HasSteps || _questCompleted)
             {
                 return false;
+            }
+
+            if (string.IsNullOrEmpty(stepId))
+            {
+                return IsCurrentStepActive(triggerType);
             }
 
             if (!_stepIndexById.TryGetValue(stepId, out var index))
@@ -91,6 +101,42 @@ namespace Synaptik.Game
             }
 
             return index == _currentIndex;
+        }
+
+        public bool TryHandleCurrentStep(QuestStepType triggerType)
+        {
+            if (!_definition.HasSteps || _questCompleted)
+            {
+                return false;
+            }
+
+            if (_currentIndex < 0 || _currentIndex >= _steps.Length)
+            {
+                return false;
+            }
+
+            if (_steps[_currentIndex].StepType != triggerType)
+            {
+                return false;
+            }
+
+            ExecuteStep(_currentIndex);
+            return true;
+        }
+
+        public bool IsCurrentStepActive(QuestStepType triggerType)
+        {
+            if (!_definition.HasSteps || _questCompleted)
+            {
+                return false;
+            }
+
+            if (_currentIndex < 0 || _currentIndex >= _steps.Length)
+            {
+                return false;
+            }
+
+            return _steps[_currentIndex].StepType == triggerType;
         }
 
         private void ExecuteStep(int index)

--- a/UserSettings/Layouts/default-6000.dwlt
+++ b/UserSettings/Layouts/default-6000.dwlt
@@ -19,116 +19,12 @@ MonoBehaviour:
     width: 1536
     height: 868.8
   m_ShowMode: 4
-  m_Title: Project
-  m_RootView: {fileID: 6}
-  m_MinSize: {x: 875, y: 300}
+  m_Title: Console
+  m_RootView: {fileID: 2}
+  m_MinSize: {x: 875, y: 382}
   m_MaxSize: {x: 10000, y: 10000}
   m_Maximized: 1
 --- !u!114 &2
-MonoBehaviour:
-  m_ObjectHideFlags: 52
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: ConsoleWindow
-  m_EditorClassIdentifier: 
-  m_Children: []
-  m_Position:
-    serializedVersion: 2
-    x: 0
-    y: 512
-    width: 340
-    height: 300.8
-  m_MinSize: {x: 101, y: 126}
-  m_MaxSize: {x: 4001, y: 4026}
-  m_ActualView: {fileID: 16}
-  m_Panes:
-  - {fileID: 16}
-  m_Selected: 0
-  m_LastSelected: 0
---- !u!114 &3
-MonoBehaviour:
-  m_ObjectHideFlags: 52
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 12010, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Children:
-  - {fileID: 15}
-  - {fileID: 2}
-  m_Position:
-    serializedVersion: 2
-    x: 1196
-    y: 0
-    width: 340
-    height: 812.8
-  m_MinSize: {x: 100, y: 100}
-  m_MaxSize: {x: 8096, y: 16192}
-  vertical: 1
-  controlID: 134
-  draggingID: 0
---- !u!114 &4
-MonoBehaviour:
-  m_ObjectHideFlags: 52
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: GameView
-  m_EditorClassIdentifier: 
-  m_Children: []
-  m_Position:
-    serializedVersion: 2
-    x: 797.6
-    y: 0
-    width: 398.40002
-    height: 302.4
-  m_MinSize: {x: 202, y: 226}
-  m_MaxSize: {x: 4002, y: 4026}
-  m_ActualView: {fileID: 19}
-  m_Panes:
-  - {fileID: 19}
-  m_Selected: 0
-  m_LastSelected: 0
---- !u!114 &5
-MonoBehaviour:
-  m_ObjectHideFlags: 52
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 12010, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Children:
-  - {fileID: 14}
-  - {fileID: 4}
-  m_Position:
-    serializedVersion: 2
-    x: 0
-    y: 510.4
-    width: 1196
-    height: 302.4
-  m_MinSize: {x: 200, y: 50}
-  m_MaxSize: {x: 16192, y: 8096}
-  vertical: 0
-  controlID: 98
-  draggingID: 0
---- !u!114 &6
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -141,9 +37,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Children:
-  - {fileID: 7}
-  - {fileID: 9}
-  - {fileID: 8}
+  - {fileID: 3}
+  - {fileID: 5}
+  - {fileID: 4}
   m_Position:
     serializedVersion: 2
     x: 0
@@ -156,7 +52,7 @@ MonoBehaviour:
   m_TopViewHeight: 36
   m_UseBottomView: 1
   m_BottomViewHeight: 20
---- !u!114 &7
+--- !u!114 &3
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -178,7 +74,7 @@ MonoBehaviour:
   m_MinSize: {x: 0, y: 0}
   m_MaxSize: {x: 0, y: 0}
   m_LastLoadedLayoutName: 
---- !u!114 &8
+--- !u!114 &4
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -199,7 +95,7 @@ MonoBehaviour:
     height: 20
   m_MinSize: {x: 0, y: 0}
   m_MaxSize: {x: 0, y: 0}
---- !u!114 &9
+--- !u!114 &5
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -212,8 +108,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Children:
-  - {fileID: 10}
-  - {fileID: 3}
+  - {fileID: 6}
+  - {fileID: 11}
   m_Position:
     serializedVersion: 2
     x: 0
@@ -223,9 +119,9 @@ MonoBehaviour:
   m_MinSize: {x: 300, y: 100}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
-  controlID: 96
+  controlID: 8630
   draggingID: 0
---- !u!114 &10
+--- !u!114 &6
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -238,8 +134,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Children:
-  - {fileID: 11}
-  - {fileID: 5}
+  - {fileID: 7}
+  - {fileID: 10}
   m_Position:
     serializedVersion: 2
     x: 0
@@ -249,9 +145,9 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 100}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 1
-  controlID: 97
+  controlID: 8631
   draggingID: 0
---- !u!114 &11
+--- !u!114 &7
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -264,8 +160,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Children:
-  - {fileID: 12}
-  - {fileID: 13}
+  - {fileID: 8}
+  - {fileID: 9}
   m_Position:
     serializedVersion: 2
     x: 0
@@ -275,9 +171,9 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 50}
   m_MaxSize: {x: 16192, y: 8096}
   vertical: 0
-  controlID: 39
+  controlID: 8577
   draggingID: 0
---- !u!114 &12
+--- !u!114 &8
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -294,16 +190,16 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 206.4
+    width: 254.4
     height: 510.4
   m_MinSize: {x: 201, y: 226}
   m_MaxSize: {x: 4001, y: 4026}
-  m_ActualView: {fileID: 17}
+  m_ActualView: {fileID: 13}
   m_Panes:
-  - {fileID: 17}
+  - {fileID: 13}
   m_Selected: 0
   m_LastSelected: 0
---- !u!114 &13
+--- !u!114 &9
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -313,23 +209,24 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 1
   m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: SceneView
+  m_Name: GameView
   m_EditorClassIdentifier: 
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 206.4
+    x: 254.4
     y: 0
-    width: 989.6
+    width: 941.6
     height: 510.4
   m_MinSize: {x: 202, y: 226}
   m_MaxSize: {x: 4002, y: 4026}
-  m_ActualView: {fileID: 18}
+  m_ActualView: {fileID: 12}
   m_Panes:
-  - {fileID: 18}
-  m_Selected: 0
+  - {fileID: 14}
+  - {fileID: 12}
+  m_Selected: 1
   m_LastSelected: 0
---- !u!114 &14
+--- !u!114 &10
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -339,23 +236,24 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 1
   m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: ProjectBrowser
+  m_Name: ConsoleWindow
   m_EditorClassIdentifier: 
   m_Children: []
   m_Position:
     serializedVersion: 2
     x: 0
-    y: 0
-    width: 797.6
+    y: 510.4
+    width: 1196
     height: 302.4
-  m_MinSize: {x: 231, y: 276}
-  m_MaxSize: {x: 10001, y: 10026}
-  m_ActualView: {fileID: 20}
+  m_MinSize: {x: 101, y: 126}
+  m_MaxSize: {x: 4001, y: 4026}
+  m_ActualView: {fileID: 16}
   m_Panes:
-  - {fileID: 20}
-  m_Selected: 0
+  - {fileID: 15}
+  - {fileID: 16}
+  m_Selected: 1
   m_LastSelected: 0
---- !u!114 &15
+--- !u!114 &11
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -370,18 +268,18 @@ MonoBehaviour:
   m_Children: []
   m_Position:
     serializedVersion: 2
-    x: 0
+    x: 1196
     y: 0
     width: 340
-    height: 512
+    height: 812.8
   m_MinSize: {x: 276, y: 76}
   m_MaxSize: {x: 4001, y: 4026}
-  m_ActualView: {fileID: 21}
+  m_ActualView: {fileID: 17}
   m_Panes:
-  - {fileID: 21}
+  - {fileID: 17}
   m_Selected: 0
   m_LastSelected: 0
---- !u!114 &16
+--- !u!114 &12
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -390,22 +288,22 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 1
-  m_Script: {fileID: 12003, guid: 0000000000000000e000000000000000, type: 0}
+  m_Script: {fileID: 12015, guid: 0000000000000000e000000000000000, type: 0}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_MinSize: {x: 100, y: 100}
+  m_MinSize: {x: 200, y: 200}
   m_MaxSize: {x: 4000, y: 4000}
   m_TitleContent:
-    m_Text: Console
-    m_Image: {fileID: -4950941429401207979, guid: 0000000000000000d000000000000000, type: 0}
+    m_Text: Game
+    m_Image: {fileID: 4621777727084837110, guid: 0000000000000000d000000000000000, type: 0}
     m_Tooltip: 
-    m_TextWithWhitespace: "Console\u200B"
+    m_TextWithWhitespace: "Game\u200B"
   m_Pos:
     serializedVersion: 2
-    x: 1
-    y: 536
-    width: 339
-    height: 274.8
+    x: 255.4
+    y: 24
+    width: 939.6
+    height: 484.4
   m_SerializedDataModeController:
     m_DataMode: 0
     m_PreferredDataMode: 0
@@ -417,7 +315,72 @@ MonoBehaviour:
     m_SaveData: []
     m_ContainerData: []
     m_OverlaysVisible: 1
---- !u!114 &17
+  m_SerializedViewNames: []
+  m_SerializedViewValues: []
+  m_PlayModeViewName: GameView
+  m_ShowGizmos: 0
+  m_TargetDisplay: 0
+  m_ClearColor: {r: 0, g: 0, b: 0, a: 0}
+  m_TargetSize: {x: 824, y: 463.4}
+  m_TextureFilterMode: 0
+  m_TextureHideFlags: 61
+  m_RenderIMGUI: 1
+  m_EnterPlayModeBehavior: 0
+  m_UseMipMap: 0
+  m_VSyncEnabled: 0
+  m_Gizmos: 0
+  m_Stats: 0
+  m_SelectedSizes: 01000000000000000000000000000000000000000000000000000000000000000000000000000000
+  m_ZoomArea:
+    m_HRangeLocked: 0
+    m_VRangeLocked: 0
+    hZoomLockedByDefault: 0
+    vZoomLockedByDefault: 0
+    m_HBaseRangeMin: -329.6
+    m_HBaseRangeMax: 329.6
+    m_VBaseRangeMin: -185.36
+    m_VBaseRangeMax: 185.36
+    m_HAllowExceedBaseRangeMin: 1
+    m_HAllowExceedBaseRangeMax: 1
+    m_VAllowExceedBaseRangeMin: 1
+    m_VAllowExceedBaseRangeMax: 1
+    m_ScaleWithWindow: 0
+    m_HSlider: 0
+    m_VSlider: 0
+    m_IgnoreScrollWheelUntilClicked: 0
+    m_EnableMouseInput: 1
+    m_EnableSliderZoomHorizontal: 0
+    m_EnableSliderZoomVertical: 0
+    m_UniformScale: 1
+    m_UpDirection: 1
+    m_DrawArea:
+      serializedVersion: 2
+      x: 0
+      y: 21
+      width: 939.6
+      height: 463.4
+    m_Scale: {x: 1.25, y: 1.25}
+    m_Translation: {x: 469.8, y: 231.7}
+    m_MarginLeft: 0
+    m_MarginRight: 0
+    m_MarginTop: 0
+    m_MarginBottom: 0
+    m_LastShownAreaInsideMargins:
+      serializedVersion: 2
+      x: -375.84
+      y: -185.36
+      width: 751.68
+      height: 370.72
+    m_MinimalGUI: 1
+  m_defaultScale: 1
+  m_LastWindowPixelSize: {x: 1174.5, y: 605.5}
+  m_ClearInEditMode: 1
+  m_NoCameraWarning: 1
+  m_LowResolutionForAspectRatios: 01000000000000000000
+  m_XRRenderMode: 0
+  m_RenderTexture: {fileID: 0}
+  m_showToolbar: 1
+--- !u!114 &13
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -440,7 +403,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 24
-    width: 205.4
+    width: 253.4
     height: 484.4
   m_SerializedDataModeController:
     m_DataMode: 0
@@ -458,7 +421,7 @@ MonoBehaviour:
       scrollPos: {x: 0, y: 0}
       m_SelectedIDs: 
       m_LastClickedID: 0
-      m_ExpandedIDs: 10f8ffff
+      m_ExpandedIDs: 6216ffffd01dffff8e23fffffc25ffff66d9ffff9af1ffffd8fafffff0fafffff6faffff00fbffff0afbffff0cfbffffbab300000eb40000b02101003c220100
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 
@@ -475,7 +438,7 @@ MonoBehaviour:
         m_OriginalEventType: 11
         m_IsRenamingFilename: 0
         m_TrimLeadingAndTrailingWhitespace: 0
-        m_ClientGUIView: {fileID: 12}
+        m_ClientGUIView: {fileID: 8}
       m_SearchString: 
     m_ExpandedScenes: []
     m_CurrenRootInstanceID: 0
@@ -483,7 +446,7 @@ MonoBehaviour:
       m_IsLocked: 0
     m_CurrentSortingName: TransformSorting
   m_WindowGUID: 4c969a2b90040154d917609493e03593
---- !u!114 &18
+--- !u!114 &14
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -504,9 +467,9 @@ MonoBehaviour:
     m_TextWithWhitespace: "Scene\u200B"
   m_Pos:
     serializedVersion: 2
-    x: 207.4
-    y: 24
-    width: 987.6
+    x: 254.40001
+    y: 79.200005
+    width: 939.6
     height: 484.4
   m_SerializedDataModeController:
     m_DataMode: 0
@@ -1070,15 +1033,15 @@ MonoBehaviour:
   m_OverrideSceneCullingMask: 6917529027641081856
   m_SceneIsLit: 1
   m_SceneLighting: 1
-  m_2DMode: 1
+  m_2DMode: 0
   m_isRotationLocked: 0
   m_PlayAudio: 0
   m_AudioPlay: 0
   m_DebugDrawModesUseInteractiveLightBakingData: 0
   m_Position:
-    m_Target: {x: 380.67456, y: 271.902, z: -14.251393}
+    m_Target: {x: 1.8840702, y: 2.9611573, z: -8.442965}
     speed: 2
-    m_Value: {x: 71.43332, y: -392.78067, z: 55.529755}
+    m_Value: {x: 1.8840702, y: 2.9611573, z: -8.442965}
   m_RenderMode: 0
   m_CameraMode:
     drawMode: 0
@@ -1111,7 +1074,7 @@ MonoBehaviour:
         m_Value: 0
       m_Color: {r: 0.5, g: 0.5, b: 0.5, a: 0.4}
       m_Pivot: {x: 0, y: 0, z: 0}
-      m_Size: {x: 0.25, y: 0.25}
+      m_Size: {x: 1, y: 1}
     zGrid:
       m_Fade:
         m_Target: 0
@@ -1124,15 +1087,15 @@ MonoBehaviour:
     m_GridAxis: 1
     m_gridOpacity: 0.5
   m_Rotation:
-    m_Target: {x: 0, y: 0, z: 0, w: 1}
+    m_Target: {x: -0.04621528, y: 0.6452445, z: -0.03915586, w: -0.76157206}
     speed: 2
-    m_Value: {x: 0.05811235, y: 0.88197166, z: -0.45413846, w: 0.11277877}
+    m_Value: {x: -0.04621528, y: 0.64524454, z: -0.039155863, w: -0.76157206}
   m_Size:
-    m_Target: 314.77472
+    m_Target: 9.334377
     speed: 2
-    m_Value: 204.29474
+    m_Value: 9.334377
   m_Ortho:
-    m_Target: 1
+    m_Target: 0
     speed: 2
     m_Value: 0
   m_CameraSettings:
@@ -1148,10 +1111,10 @@ MonoBehaviour:
     m_FarClip: 10000
     m_DynamicClip: 1
     m_OcclusionCulling: 0
-  m_LastSceneViewRotation: {x: -0.05811235, y: -0.88197166, z: 0.45413846, w: -0.11277877}
+  m_LastSceneViewRotation: {x: -0.08717229, y: 0.89959055, z: -0.21045254, w: -0.3726226}
   m_LastSceneViewOrtho: 0
   m_Viewpoint:
-    m_SceneView: {fileID: 18}
+    m_SceneView: {fileID: 14}
     m_CameraOverscanSettings:
       m_Opacity: 50
       m_Scale: 1
@@ -1164,108 +1127,7 @@ MonoBehaviour:
     name: Contributors / Receivers
     section: Lighting
   m_ViewIsLockedToObject: 0
---- !u!114 &19
-MonoBehaviour:
-  m_ObjectHideFlags: 52
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 1
-  m_Script: {fileID: 12015, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_MinSize: {x: 200, y: 200}
-  m_MaxSize: {x: 4000, y: 4000}
-  m_TitleContent:
-    m_Text: Game
-    m_Image: {fileID: 4621777727084837110, guid: 0000000000000000d000000000000000, type: 0}
-    m_Tooltip: 
-    m_TextWithWhitespace: "Game\u200B"
-  m_Pos:
-    serializedVersion: 2
-    x: 798.6
-    y: 24
-    width: 396.40002
-    height: 276.4
-  m_SerializedDataModeController:
-    m_DataMode: 0
-    m_PreferredDataMode: 0
-    m_SupportedDataModes: 
-    isAutomatic: 1
-  m_ViewDataDictionary: {fileID: 0}
-  m_OverlayCanvas:
-    m_LastAppliedPresetName: Default
-    m_SaveData: []
-    m_ContainerData: []
-    m_OverlaysVisible: 1
-  m_SerializedViewNames: []
-  m_SerializedViewValues: []
-  m_PlayModeViewName: GameView
-  m_ShowGizmos: 0
-  m_TargetDisplay: 0
-  m_ClearColor: {r: 0, g: 0, b: 0, a: 0}
-  m_TargetSize: {x: 396.40002, y: 223}
-  m_TextureFilterMode: 0
-  m_TextureHideFlags: 61
-  m_RenderIMGUI: 1
-  m_EnterPlayModeBehavior: 0
-  m_UseMipMap: 0
-  m_VSyncEnabled: 0
-  m_Gizmos: 0
-  m_Stats: 0
-  m_SelectedSizes: 01000000000000000000000000000000000000000000000000000000000000000000000000000000
-  m_ZoomArea:
-    m_HRangeLocked: 0
-    m_VRangeLocked: 0
-    hZoomLockedByDefault: 0
-    vZoomLockedByDefault: 0
-    m_HBaseRangeMin: -158.56001
-    m_HBaseRangeMax: 158.56001
-    m_VBaseRangeMin: -89.200005
-    m_VBaseRangeMax: 89.200005
-    m_HAllowExceedBaseRangeMin: 1
-    m_HAllowExceedBaseRangeMax: 1
-    m_VAllowExceedBaseRangeMin: 1
-    m_VAllowExceedBaseRangeMax: 1
-    m_ScaleWithWindow: 0
-    m_HSlider: 1
-    m_VSlider: 0
-    m_IgnoreScrollWheelUntilClicked: 0
-    m_EnableMouseInput: 1
-    m_EnableSliderZoomHorizontal: 0
-    m_EnableSliderZoomVertical: 0
-    m_UniformScale: 1
-    m_UpDirection: 1
-    m_DrawArea:
-      serializedVersion: 2
-      x: 0
-      y: 21
-      width: 396.40002
-      height: 255.4
-    m_Scale: {x: 1.5, y: 1.5}
-    m_Translation: {x: 198.20001, y: 127.7}
-    m_MarginLeft: 0
-    m_MarginRight: 0
-    m_MarginTop: 0
-    m_MarginBottom: 0
-    m_LastShownAreaInsideMargins:
-      serializedVersion: 2
-      x: -132.13335
-      y: -85.13333
-      width: 264.2667
-      height: 170.26666
-    m_MinimalGUI: 1
-  m_defaultScale: 1
-  m_LastWindowPixelSize: {x: 495.50003, y: 345.5}
-  m_ClearInEditMode: 1
-  m_NoCameraWarning: 1
-  m_LowResolutionForAspectRatios: 01000000000000000000
-  m_XRRenderMode: 0
-  m_RenderTexture: {fileID: 0}
-  m_showToolbar: 1
---- !u!114 &20
+--- !u!114 &15
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1287,8 +1149,8 @@ MonoBehaviour:
   m_Pos:
     serializedVersion: 2
     x: 0
-    y: 24
-    width: 796.6
+    y: 589.60004
+    width: 1195
     height: 276.4
   m_SerializedDataModeController:
     m_DataMode: 0
@@ -1312,7 +1174,7 @@ MonoBehaviour:
     m_SkipHidden: 0
     m_SearchArea: 1
     m_Folders:
-    - Assets/_Project/Art/Models
+    - Assets/_Project/Scripts/Gameplay/Alien
     m_Globs: []
     m_ProductIds: 
     m_AnyWithAssetOrigin: 0
@@ -1322,16 +1184,16 @@ MonoBehaviour:
   m_ViewMode: 1
   m_StartGridSize: 64
   m_LastFolders:
-  - Assets/_Project/Art/Models/Environments/Structures
+  - Assets/_Project/Scripts/Gameplay/Alien
   m_LastFoldersGridSize: -1
-  m_LastProjectPath: D:\epic art\iim\alt ctrl\GIT\Synaptik
+  m_LastProjectPath: C:\Apps\Unity\Synaptik
   m_LockTracker:
     m_IsLocked: 0
   m_FolderTreeState:
-    scrollPos: {x: 0, y: 15.3333435}
-    m_SelectedIDs: 3c730000
-    m_LastClickedID: 29500
-    m_ExpandedIDs: 00000000e6b60000
+    scrollPos: {x: 0, y: 31.600006}
+    m_SelectedIDs: 12bc0000
+    m_LastClickedID: 48146
+    m_ExpandedIDs: 0000000026c80000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -1360,7 +1222,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: 00000000e6b60000
+    m_ExpandedIDs: 0000000026c80000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -1386,8 +1248,8 @@ MonoBehaviour:
       m_Icon: {fileID: 0}
       m_ResourceFile: 
   m_ListAreaState:
-    m_SelectedInstanceIDs: 
-    m_LastClickedInstanceID: 0
+    m_SelectedInstanceIDs: deb20000
+    m_LastClickedInstanceID: 45790
     m_HadKeyboardFocusLastEvent: 1
     m_ExpandedInstanceIDs: c6230000
     m_RenameOverlay:
@@ -1406,7 +1268,7 @@ MonoBehaviour:
       m_OriginalEventType: 11
       m_IsRenamingFilename: 1
       m_TrimLeadingAndTrailingWhitespace: 0
-      m_ClientGUIView: {fileID: 14}
+      m_ClientGUIView: {fileID: 9}
     m_CreateAssetUtility:
       m_EndAction: {fileID: 0}
       m_InstanceID: 0
@@ -1418,7 +1280,43 @@ MonoBehaviour:
     m_GridSize: 64
   m_SkipHiddenPackages: 0
   m_DirectoriesAreaWidth: 207
---- !u!114 &21
+--- !u!114 &16
+MonoBehaviour:
+  m_ObjectHideFlags: 52
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 1
+  m_Script: {fileID: 12003, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_MinSize: {x: 100, y: 100}
+  m_MaxSize: {x: 4000, y: 4000}
+  m_TitleContent:
+    m_Text: Console
+    m_Image: {fileID: -4950941429401207979, guid: 0000000000000000d000000000000000, type: 0}
+    m_Tooltip: 
+    m_TextWithWhitespace: "Console\u200B"
+  m_Pos:
+    serializedVersion: 2
+    x: 0
+    y: 534.4
+    width: 1195
+    height: 276.39996
+  m_SerializedDataModeController:
+    m_DataMode: 0
+    m_PreferredDataMode: 0
+    m_SupportedDataModes: 
+    isAutomatic: 1
+  m_ViewDataDictionary: {fileID: 0}
+  m_OverlayCanvas:
+    m_LastAppliedPresetName: Default
+    m_SaveData: []
+    m_ContainerData: []
+    m_OverlaysVisible: 1
+--- !u!114 &17
 MonoBehaviour:
   m_ObjectHideFlags: 52
   m_CorrespondingSourceObject: {fileID: 0}
@@ -1439,10 +1337,10 @@ MonoBehaviour:
     m_TextWithWhitespace: "Inspector\u200B"
   m_Pos:
     serializedVersion: 2
-    x: 1
+    x: 1197
     y: 24
     width: 339
-    height: 486
+    height: 786.8
   m_SerializedDataModeController:
     m_DataMode: 0
     m_PreferredDataMode: 0
@@ -1461,7 +1359,7 @@ MonoBehaviour:
     m_ControlHash: -371814159
     m_PrefName: Preview_InspectorPreview
   m_LastInspectedObjectInstanceID: -1
-  m_LastVerticalScrollValue: 146
+  m_LastVerticalScrollValue: 0
   m_GlobalObjectId: 
   m_InspectorMode: 0
   m_LockTracker:


### PR DESCRIPTION
## Summary
- ensure alien dialogue bubbles reference scene instances so speech displays correctly
- relax quest runtime checks so interaction rules without explicit step IDs advance the current step
- gate dialogue rules on the active quest step to prevent repeating the same lines

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68e8fb0269e88330b7a9db9112e42dfc