### PR TITLE
Cache alien interaction rules for fallback

### DIFF
--- a/Assets/_Project/Scripts/Gameplay/Alien/Alien.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/Alien.cs
@@ -164,6 +164,14 @@ namespace Synaptik.Game
                     return;
                 }
 
+                if (_def.Reactions.TryFindRule(channel, playerEmotion, null, out var fallbackRule))
+                {
+                    Debug.Log($"[Alien] No interaction rule available for {name} with combo {channel}/{playerEmotion}. Using definition fallback.");
+                    _cachedInteractionRules[interactionKey] = fallbackRule;
+                    HandleInteractionRule(fallbackRule, channel, playerEmotion, false);
+                    return;
+                }
+
                 Debug.LogWarning($"[Alien] No interaction rule found for {name} with combo {channel}/{playerEmotion}");
                 return;
             }


### PR DESCRIPTION
## Summary
- cache the last successful interaction rule per combo on each alien
- reuse the cached rule when a quest-gated rule becomes unavailable to keep interactions responsive
- avoid reprocessing quest progress when replaying cached rules

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68e90d8a79fc8330a89c9ac7f6522c28