### PR TITLE
Make fearful aliens flee faster and shrink stop zone

### DIFF
--- a/Assets/_Project/Scripts/Gameplay/Alien/AlienWander.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/AlienWander.cs
@@ -159,7 +159,7 @@ public sealed class AlienWander : MonoBehaviour
             yield break;
 
         float stopDistance = fearfulPlayerDistance;
-        float freezeDistance = detectionRadius;
+        float freezeDistance = GetCurrentDetectionRadius();
         float minFleeTime = 0.4f;
         float timer = 0f;
 

--- a/Assets/_Project/Scripts/Gameplay/Alien/AlienWander.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/AlienWander.cs
@@ -9,6 +9,9 @@ public sealed class AlienWander : MonoBehaviour
     private Transform player;
 
     [SerializeField]
+    private Alien alien;
+
+    [SerializeField]
     private float detectionRadius = 6f;
 
     [Header("Paramètres de déplacement")]
@@ -20,6 +23,13 @@ public sealed class AlienWander : MonoBehaviour
 
     [SerializeField]
     private float moveSpeed = 2f;
+
+    [SerializeField]
+    private float fearfulSpeedMultiplier = 1.5f;
+
+    [SerializeField]
+    [Min(0f)]
+    private float fearfulDetectionRadiusMultiplier = 0.6f;
 
     [SerializeField]
     private float waitTimeMin = 1f;
@@ -40,6 +50,10 @@ public sealed class AlienWander : MonoBehaviour
     private void Start()
     {
         controller = GetComponent<CharacterController>();
+        if (!alien)
+        {
+            alien = GetComponent<Alien>();
+        }
         origin = transform.position;
 
         if (canMove)
@@ -58,6 +72,12 @@ public sealed class AlienWander : MonoBehaviour
 
             while (!HasReachedTarget())
             {
+                if (ShouldFlee())
+                {
+                    yield return FleeRoutine();
+                    break;
+                }
+
                 if (IsPlayerClose())
                 {
                     break;
@@ -84,6 +104,11 @@ public sealed class AlienWander : MonoBehaviour
 
         while (IsPlayerClose())
         {
+            if (ShouldFlee())
+            {
+                yield break;
+            }
+
             LookAtPlayer();
             yield return null;
         }
@@ -98,7 +123,7 @@ public sealed class AlienWander : MonoBehaviour
 
         var current = new Vector3(transform.position.x, 0f, transform.position.z);
         var targetPos = new Vector3(player.position.x, 0f, player.position.z);
-        return Vector3.Distance(current, targetPos) <= detectionRadius;
+        return Vector3.Distance(current, targetPos) <= GetCurrentDetectionRadius();
     }
 
     private void LookAtPlayer()
@@ -125,15 +150,7 @@ public sealed class AlienWander : MonoBehaviour
         var direction = (target - transform.position).normalized;
         direction.y = 0f;
 
-        if (direction != Vector3.zero)
-        {
-            var targetRotation = Quaternion.LookRotation(direction);
-            transform.rotation = Quaternion.Slerp(transform.rotation, targetRotation, Time.deltaTime * rotationSpeed);
-        }
-
-        verticalVelocity = controller.isGrounded ? -1f : verticalVelocity + Gravity * Time.deltaTime;
-        var velocity = direction * moveSpeed + Vector3.up * verticalVelocity;
-        controller.Move(velocity * Time.deltaTime);
+        MoveInDirection(direction, moveSpeed);
     }
 
     private Vector3 GetRandomPointAround(Vector3 center, float radius)
@@ -166,6 +183,71 @@ public sealed class AlienWander : MonoBehaviour
         Gizmos.DrawWireSphere(Application.isPlaying ? origin : transform.position, moveRadius);
 
         Gizmos.color = Color.red;
-        Gizmos.DrawWireSphere(transform.position, detectionRadius);
+        Gizmos.DrawWireSphere(transform.position, Application.isPlaying ? GetCurrentDetectionRadius() : detectionRadius);
+    }
+
+    private bool ShouldFlee()
+    {
+        return canMove && player != null && alien != null && alien.Emotion == Emotion.Fearful;
+    }
+
+    private IEnumerator FleeRoutine()
+    {
+        while (ShouldFlee())
+        {
+            MoveAwayFromPlayer();
+            yield return null;
+        }
+    }
+
+    private void MoveAwayFromPlayer()
+    {
+        if (player == null)
+        {
+            return;
+        }
+
+        var direction = transform.position - player.position;
+        direction.y = 0f;
+
+        if (direction.sqrMagnitude < 0.0001f)
+        {
+            direction = Random.insideUnitSphere;
+            direction.y = 0f;
+            if (direction.sqrMagnitude < 0.0001f)
+            {
+                direction = Vector3.forward;
+            }
+        }
+
+        direction.Normalize();
+        MoveInDirection(direction, moveSpeed * fearfulSpeedMultiplier);
+    }
+
+    private void MoveInDirection(Vector3 direction, float speed)
+    {
+        if (direction != Vector3.zero)
+        {
+            var targetRotation = Quaternion.LookRotation(direction);
+            transform.rotation = Quaternion.Slerp(transform.rotation, targetRotation, Time.deltaTime * rotationSpeed);
+        }
+        else
+        {
+            return;
+        }
+
+        verticalVelocity = controller.isGrounded ? -1f : verticalVelocity + Gravity * Time.deltaTime;
+        var velocity = direction * speed + Vector3.up * verticalVelocity;
+        controller.Move(velocity * Time.deltaTime);
+    }
+
+    private float GetCurrentDetectionRadius()
+    {
+        if (alien != null && alien.Emotion == Emotion.Fearful)
+        {
+            return Mathf.Max(0f, detectionRadius * fearfulDetectionRadiusMultiplier);
+        }
+
+        return Mathf.Max(0f, detectionRadius);
     }
 }

--- a/UserSettings/EditorUserSettings.asset
+++ b/UserSettings/EditorUserSettings.asset
@@ -18,16 +18,16 @@ EditorUserSettings:
       value: 5006035452015a0d595f5e744671594442154d7c2a702732787b4d36bbb8316f
       flags: 0
     RecentlyUsedSceneGuid-3:
-      value: 0253000252505f5a585e582040755944454f4e737a7b7064797f4b60b0e46d39
-      flags: 0
-    RecentlyUsedSceneGuid-4:
-      value: 0253000252505f5a585e582040755944454f4e737a7b7064797f4b60b0e46d39
-      flags: 0
-    RecentlyUsedSceneGuid-5:
       value: 025450025553500e0c5b0a2347750e44421648727e2c71697a7f4862b3b36661
       flags: 0
-    RecentlyUsedSceneGuid-6:
+    RecentlyUsedSceneGuid-4:
       value: 0609000257065f0b5a585d7b46200c44174e4e73287b2269752a4e31b0b9323b
+      flags: 0
+    RecentlyUsedSceneGuid-5:
+      value: 510650005d565a0b09575a2116735b44444f4b7b287e763278701c64b7b0673c
+      flags: 0
+    RecentlyUsedSceneGuid-6:
+      value: 0253000252505f5a585e582040755944454f4e737a7b7064797f4b60b0e46d39
       flags: 0
     RecentlyUsedSceneGuid-7:
       value: 510650005d565a0b09575a2116735b44444f4b7b287e763278701c64b7b0673c

--- a/UserSettings/Layouts/CurrentMaximizeLayout.dwlt
+++ b/UserSettings/Layouts/CurrentMaximizeLayout.dwlt
@@ -24,7 +24,7 @@ MonoBehaviour:
   m_MinSize: {x: 300, y: 100}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
-  controlID: 4851
+  controlID: 40
   draggingID: 0
 --- !u!114 &2
 MonoBehaviour:
@@ -65,7 +65,7 @@ MonoBehaviour:
   m_SerializedViewNames: []
   m_SerializedViewValues: []
   m_PlayModeViewName: GameView
-  m_ShowGizmos: 0
+  m_ShowGizmos: 1
   m_TargetDisplay: 0
   m_ClearColor: {r: 0, g: 0, b: 0, a: 0}
   m_TargetSize: {x: 1920, y: 1080}
@@ -75,7 +75,7 @@ MonoBehaviour:
   m_EnterPlayModeBehavior: 0
   m_UseMipMap: 0
   m_VSyncEnabled: 0
-  m_Gizmos: 0
+  m_Gizmos: 1
   m_Stats: 0
   m_SelectedSizes: 03000000000000000000000000000000000000000000000000000000000000000000000000000000
   m_ZoomArea:
@@ -95,7 +95,7 @@ MonoBehaviour:
     m_HSlider: 0
     m_VSlider: 0
     m_IgnoreScrollWheelUntilClicked: 0
-    m_EnableMouseInput: 1
+    m_EnableMouseInput: 0
     m_EnableSliderZoomHorizontal: 0
     m_EnableSliderZoomVertical: 0
     m_UniformScale: 1
@@ -151,7 +151,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 100}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 1
-  controlID: 4852
+  controlID: 41
   draggingID: 0
 --- !u!114 &4
 MonoBehaviour:
@@ -177,7 +177,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 50}
   m_MaxSize: {x: 16192, y: 8096}
   vertical: 0
-  controlID: 4853
+  controlID: 42
   draggingID: 0
 --- !u!114 &5
 MonoBehaviour:
@@ -244,9 +244,9 @@ MonoBehaviour:
   m_SceneHierarchy:
     m_TreeViewState:
       scrollPos: {x: 0, y: 0}
-      m_SelectedIDs: 484b0000
-      m_LastClickedID: 0
-      m_ExpandedIDs: 1cd5ffff68d6ffff06fbffff38c500006cd1000000d20000
+      m_SelectedIDs: c6240100
+      m_LastClickedID: 74950
+      m_ExpandedIDs: 2050feffd252feff3ae9feff0857ffff1457ffff0e69ffff4a77ffff487cffff4cbfffffcac3ffff7cf2ffff0cfbfffff4fffffffac9000018ca0000b8d50000ded50000d0ec00001aed0000
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 
@@ -885,15 +885,15 @@ MonoBehaviour:
   m_OverrideSceneCullingMask: 6917529027641081856
   m_SceneIsLit: 1
   m_SceneLighting: 1
-  m_2DMode: 0
+  m_2DMode: 1
   m_isRotationLocked: 0
   m_PlayAudio: 0
   m_AudioPlay: 0
   m_DebugDrawModesUseInteractiveLightBakingData: 0
   m_Position:
-    m_Target: {x: 6.1910334, y: 1.7658503, z: 0.40239143}
+    m_Target: {x: 857.6598, y: 521.48505, z: -14.535566}
     speed: 2
-    m_Value: {x: 6.1910334, y: 1.7658503, z: 0.40239143}
+    m_Value: {x: 857.6598, y: 521.48505, z: -14.535566}
   m_RenderMode: 0
   m_CameraMode:
     drawMode: 0
@@ -939,17 +939,17 @@ MonoBehaviour:
     m_GridAxis: 1
     m_gridOpacity: 0.5
   m_Rotation:
-    m_Target: {x: -0.08430862, y: 0.41769108, z: -0.03896158, w: -0.9038334}
+    m_Target: {x: 0, y: 0, z: 0, w: 1}
     speed: 2
-    m_Value: {x: -0.08430835, y: 0.41768974, z: -0.03896145, w: -0.90383047}
+    m_Value: {x: 0, y: 0, z: 0, w: 1}
   m_Size:
-    m_Target: 9.334377
+    m_Target: 800.48206
     speed: 2
-    m_Value: 9.334377
+    m_Value: 800.48206
   m_Ortho:
-    m_Target: 0
+    m_Target: 1
     speed: 2
-    m_Value: 0
+    m_Value: 1
   m_CameraSettings:
     m_Speed: 2
     m_SpeedNormalized: 1
@@ -963,7 +963,7 @@ MonoBehaviour:
     m_FarClip: 10000
     m_DynamicClip: 1
     m_OcclusionCulling: 0
-  m_LastSceneViewRotation: {x: -0.08717229, y: 0.89959055, z: -0.21045254, w: -0.3726226}
+  m_LastSceneViewRotation: {x: 0.24237093, y: -0.25788283, z: 0.06710726, w: 0.93289864}
   m_LastSceneViewOrtho: 0
   m_Viewpoint:
     m_SceneView: {fileID: 8}
@@ -1053,7 +1053,7 @@ MonoBehaviour:
     m_SkipHidden: 0
     m_SearchArea: 1
     m_Folders:
-    - Assets/_Project/Scripts/Gameplay/Player
+    - Assets/_Project/Scripts/Gameplay/Alien/SO/Alien1
     m_Globs: []
     m_ProductIds: 
     m_AnyWithAssetOrigin: 0
@@ -1063,16 +1063,16 @@ MonoBehaviour:
   m_ViewMode: 1
   m_StartGridSize: 64
   m_LastFolders:
-  - Assets/_Project/Scripts/Gameplay/Player
+  - Assets/_Project/Scripts/Gameplay/Alien/SO/Alien1
   m_LastFoldersGridSize: -1
   m_LastProjectPath: C:\Apps\Unity\Synaptik
   m_LockTracker:
     m_IsLocked: 0
   m_FolderTreeState:
-    scrollPos: {x: 0, y: 63.600006}
-    m_SelectedIDs: fcc90000
-    m_LastClickedID: 51708
-    m_ExpandedIDs: 0000000026c80000a2c90000ecc90000eec9000000ca9a3bffffff7f
+    scrollPos: {x: 0, y: 95}
+    m_SelectedIDs: 34c90000
+    m_LastClickedID: 51508
+    m_ExpandedIDs: 000000007ec80000ecc8000036c9000038c900003ac900003cc9000000ca9a3bffffff7f
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -1101,7 +1101,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: 0000000026c8000000ca9a3bffffff7f
+    m_ExpandedIDs: 000000007ec80000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -1127,8 +1127,8 @@ MonoBehaviour:
       m_Icon: {fileID: 0}
       m_ResourceFile: 
   m_ListAreaState:
-    m_SelectedInstanceIDs: 484b0000
-    m_LastClickedInstanceID: 19272
+    m_SelectedInstanceIDs: c6240100
+    m_LastClickedInstanceID: 74950
     m_HadKeyboardFocusLastEvent: 1
     m_ExpandedInstanceIDs: c6230000
     m_RenameOverlay:
@@ -1214,8 +1214,8 @@ MonoBehaviour:
     y: 0
     width: 340
     height: 812.8
-  m_MinSize: {x: 276, y: 76}
-  m_MaxSize: {x: 4001, y: 4026}
+  m_MinSize: {x: 275, y: 50}
+  m_MaxSize: {x: 4000, y: 4000}
   m_ActualView: {fileID: 13}
   m_Panes:
   - {fileID: 13}


### PR DESCRIPTION
## Summary
- make alien wander logic aware of their current emotion
- force fearful aliens to flee from the player with an increased speed
- refactor movement helpers to share rotation and controller motion handling
- shrink the detection radius while aliens are fearful so their stop zone is smaller

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea45c30ee8833084ee34d863477418