### PR TITLE
Fix camera relative player movement

### DIFF
--- a/Assets/_Project/Scripts/Gameplay/Player/PlayerMovement.cs
+++ b/Assets/_Project/Scripts/Gameplay/Player/PlayerMovement.cs
@@ -73,9 +73,17 @@ public sealed class PlayerMovement : MonoBehaviour
 
         Vector3 camForward = targetCamera.transform.forward;
         camForward.y = 0f;
-        camForward.Normalize();
+        if (camForward.sqrMagnitude < 0.0001f)
+            camForward = Vector3.forward;
+        else
+            camForward.Normalize();
 
-        Vector3 camRight = Vector3.Cross(Vector3.up, camForward).normalized;
+        Vector3 camRight = targetCamera.transform.right;
+        camRight.y = 0f;
+        if (camRight.sqrMagnitude < 0.0001f)
+            camRight = Vector3.right;
+        else
+            camRight.Normalize();
 
         Vector3 moveDir = (camForward * input.y + camRight * input.x);
         return moveDir.sqrMagnitude > 1f ? moveDir.normalized : moveDir;


### PR DESCRIPTION
## Summary
- adjust player movement vectors to use the camera's right axis instead of a global cross product
- normalize camera forward/right projections defensively to avoid inverted controls when the camera looks straight down

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ecc12bf4dc8330b293044d5e5b7def