### PR TITLE
Add temporary fearful action speed boost for player

### DIFF
--- a/Assets/_Project/Scripts/Gameplay/Player/PlayerMovement.cs
+++ b/Assets/_Project/Scripts/Gameplay/Player/PlayerMovement.cs
@@ -24,6 +24,9 @@ public sealed class PlayerMovement : MonoBehaviour
     [SerializeField, Min(0f)]
     private float fearfulActionBoostDuration = 2f;
 
+    [SerializeField, Min(0f)]
+    private float fearfulActionBoostDecayDuration = 1f;
+
     [Header("Camera-relative ?")]
     [SerializeField]
     private bool cameraRelative = true;
@@ -140,16 +143,27 @@ public sealed class PlayerMovement : MonoBehaviour
 
     private void UpdateSpeedBoost(float deltaTime)
     {
-        if (speedBoostTimer <= 0f)
-            return;
-
-        speedBoostTimer -= deltaTime;
-
         if (speedBoostTimer > 0f)
+        {
+            speedBoostTimer -= deltaTime;
+
+            if (speedBoostTimer > 0f)
+                return;
+
+            speedBoostTimer = 0f;
+        }
+
+        if (currentSpeedBonus <= 0f)
             return;
 
-        speedBoostTimer = 0f;
-        currentSpeedBonus = 0f;
+        if (fearfulActionBoostDecayDuration <= 0f)
+        {
+            currentSpeedBonus = 0f;
+            return;
+        }
+
+        float decayRate = fearfulActionSpeedBonus / fearfulActionBoostDecayDuration;
+        currentSpeedBonus = Mathf.Max(0f, currentSpeedBonus - decayRate * deltaTime);
     }
 
     private Vector3 GetMovementDirection(Vector2 input)

--- a/Assets/_Project/Scripts/Gameplay/Player/PlayerMovement.cs
+++ b/Assets/_Project/Scripts/Gameplay/Player/PlayerMovement.cs
@@ -27,6 +27,9 @@ public sealed class PlayerMovement : MonoBehaviour
     [SerializeField, Min(0f)]
     private float fearfulActionBoostDecayDuration = 1f;
 
+    [SerializeField, Min(0f)]
+    private float fearfulActionBoostCooldown = 3f;
+
     [Header("Camera-relative ?")]
     [SerializeField]
     private bool cameraRelative = true;
@@ -40,6 +43,7 @@ public sealed class PlayerMovement : MonoBehaviour
 
     private float currentSpeedBonus;
     private float speedBoostTimer;
+    private float speedBoostCooldownTimer;
     private InputsDetection cachedInputsDetection;
     private bool isSubscribedToInputs;
 
@@ -87,6 +91,7 @@ public sealed class PlayerMovement : MonoBehaviour
         var direction = GetMovementDirection(input);
 
         UpdateSpeedBoost(Time.fixedDeltaTime);
+        UpdateSpeedBoostCooldown(Time.fixedDeltaTime);
 
         var currentMaxSpeed = maxSpeed + currentSpeedBonus;
 
@@ -137,8 +142,12 @@ public sealed class PlayerMovement : MonoBehaviour
         if (emotion != Emotion.Fearful || behavior != Behavior.Action)
             return;
 
+        if (speedBoostCooldownTimer > 0f)
+            return;
+
         currentSpeedBonus = fearfulActionSpeedBonus;
         speedBoostTimer = fearfulActionBoostDuration;
+        speedBoostCooldownTimer = fearfulActionBoostCooldown;
     }
 
     private void UpdateSpeedBoost(float deltaTime)
@@ -164,6 +173,14 @@ public sealed class PlayerMovement : MonoBehaviour
 
         float decayRate = fearfulActionSpeedBonus / fearfulActionBoostDecayDuration;
         currentSpeedBonus = Mathf.Max(0f, currentSpeedBonus - decayRate * deltaTime);
+    }
+
+    private void UpdateSpeedBoostCooldown(float deltaTime)
+    {
+        if (speedBoostCooldownTimer <= 0f)
+            return;
+
+        speedBoostCooldownTimer = Mathf.Max(0f, speedBoostCooldownTimer - deltaTime);
     }
 
     private Vector3 GetMovementDirection(Vector2 input)


### PR DESCRIPTION
## Summary
- add configuration for a fearful action speed boost on the player
- subscribe player movement to emotion/action combos
- temporarily increase the maximum speed when triggering the fearful action combo

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ecff9978608330b3d0c3b66be164ed