### PR TITLE
Add quest step support to dialogue lines

### DIFF
--- a/Assets/_Project/Scripts/Gameplay/Alien/Alien.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/Alien.cs
@@ -351,6 +351,11 @@ public class Alien : MonoBehaviour, IInteraction
     {
         var handled = allowQuestProgress && ProcessQuestStep(rule.QuestId, rule.QuestStepId, QuestStepType.Talk);
 
+        if (handled)
+        {
+            TryShowQuestStepDialogue(rule.QuestStepId, "interaction");
+        }
+
         if (rule.SetNewEmotion)
         {
             SetEmotion(rule.NewEmotion);
@@ -388,6 +393,11 @@ public class Alien : MonoBehaviour, IInteraction
     private void HandleItemRule(ItemRule rule, string itemId)
     {
         var handled = ProcessQuestStep(rule.QuestId, rule.QuestStepId, QuestStepType.GiveItem);
+
+        if (handled)
+        {
+            TryShowQuestStepDialogue(rule.QuestStepId, "item");
+        }
 
         if (rule.SetIfGoodItem)
         {
@@ -431,6 +441,20 @@ public class Alien : MonoBehaviour, IInteraction
 
         if (_def.Dialogue.TryGet(itemId, out var entry))
         {
+            ShowDialogue(entry.EmojiLine, entry.Duration);
+        }
+    }
+
+    private void TryShowQuestStepDialogue(string questStepId, string source)
+    {
+        if (string.IsNullOrWhiteSpace(questStepId) || !_dialogueBubble || !_def?.Dialogue)
+        {
+            return;
+        }
+
+        if (_def.Dialogue.TryGetForQuestStep(questStepId, out var entry))
+        {
+            Debug.Log($"[Alien] Showing quest step dialogue '{entry.EmojiLine}' for {name} at step '{questStepId}' from {source}.");
             ShowDialogue(entry.EmojiLine, entry.Duration);
         }
     }

--- a/Assets/_Project/Scripts/Gameplay/Alien/DataScripts/DialogueDatabase.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/DataScripts/DialogueDatabase.cs
@@ -19,10 +19,14 @@ public class DialogueDatabase : ScriptableObject
         [SerializeField]
         private float duration;
 
+        [SerializeField]
+        private string questStepId;
+
         public Emotion Emotion => emotion;
         public Behavior Behavior => behavior;
         public string EmojiLine => emojiLine;
         public float Duration => duration <= 0f ? 2f : duration;
+        public string QuestStepId => questStepId;
     }
 
     [Serializable]
@@ -52,6 +56,11 @@ public class DialogueDatabase : ScriptableObject
     {
         for (var i = 0; i < entries.Length; i++)
         {
+            if (!string.IsNullOrWhiteSpace(entries[i].QuestStepId))
+            {
+                continue;
+            }
+
             if (entries[i].Emotion == emotion && entries[i].Behavior == behavior)
             {
                 entry = entries[i];
@@ -70,6 +79,32 @@ public class DialogueDatabase : ScriptableObject
             if (itemEntries[i].ItemId == itemId)
             {
                 entry = itemEntries[i];
+                return true;
+            }
+        }
+
+        entry = default;
+        return false;
+    }
+
+    public bool TryGetForQuestStep(string questStepId, out Entry entry)
+    {
+        if (string.IsNullOrWhiteSpace(questStepId))
+        {
+            entry = default;
+            return false;
+        }
+
+        for (var i = 0; i < entries.Length; i++)
+        {
+            if (string.IsNullOrWhiteSpace(entries[i].QuestStepId))
+            {
+                continue;
+            }
+
+            if (entries[i].QuestStepId == questStepId)
+            {
+                entry = entries[i];
                 return true;
             }
         }


### PR DESCRIPTION
## Summary
- allow dialogue entries to include an optional quest step identifier
- play quest step-specific dialogue lines when their corresponding step is completed while keeping default behaviour for other lines

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68ed098218988330a8d47bdf8755c8dc