### PR TITLE
Add camera focus and highlighting for alien interactions

### DIFF
--- a/Assets/_Project/Scripts/Gameplay/InteractableHighlighter.cs
+++ b/Assets/_Project/Scripts/Gameplay/InteractableHighlighter.cs
@@ -1,0 +1,197 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public sealed class InteractableHighlighter : MonoBehaviour
+{
+    [SerializeField]
+    private Renderer[] renderers = System.Array.Empty<Renderer>();
+
+    [SerializeField, ColorUsage(false, true)]
+    private Color defaultHighlightColor = Color.cyan;
+
+    [SerializeField, Min(0f)]
+    private float emissionBoost = 2f;
+
+    [SerializeField, Range(0f, 1f)]
+    private float colorBlend = 0.35f;
+
+    private readonly List<RendererState> rendererStates = new();
+    private bool isInitialized;
+    private bool isHighlighted;
+    private Color currentColor;
+    private float currentEmissionBoost;
+
+    private static readonly int EmissionColorId = Shader.PropertyToID("_EmissionColor");
+    private static readonly int BaseColorId = Shader.PropertyToID("_BaseColor");
+    private static readonly int ColorId = Shader.PropertyToID("_Color");
+
+    private void Awake()
+    {
+        InitializeRenderers();
+    }
+
+    private void OnValidate()
+    {
+        if (!Application.isPlaying)
+        {
+            isInitialized = false;
+            InitializeRenderers();
+            ApplyHighlight(false, defaultHighlightColor, emissionBoost);
+        }
+        else if (isHighlighted)
+        {
+            ApplyHighlight(true, currentColor, currentEmissionBoost);
+        }
+    }
+
+    private void OnDisable()
+    {
+        if (isHighlighted)
+        {
+            ApplyHighlight(false, currentColor, currentEmissionBoost);
+        }
+    }
+
+    public void RefreshRenderers()
+    {
+        isInitialized = false;
+        InitializeRenderers();
+        if (isHighlighted)
+        {
+            ApplyHighlight(true, currentColor, currentEmissionBoost);
+        }
+    }
+
+    public void SetHighlighted(bool highlighted, Color color, float emissionMultiplier)
+    {
+        InitializeRenderers();
+
+        isHighlighted = highlighted;
+        currentColor = highlighted ? color : defaultHighlightColor;
+        currentEmissionBoost = emissionMultiplier;
+
+        ApplyHighlight(highlighted, color, emissionMultiplier);
+    }
+
+    private void InitializeRenderers()
+    {
+        if (renderers == null || renderers.Length == 0)
+        {
+            renderers = GetComponentsInChildren<Renderer>(true);
+        }
+
+        if (renderers == null)
+        {
+            renderers = System.Array.Empty<Renderer>();
+        }
+
+        if (isInitialized)
+            return;
+
+        rendererStates.Clear();
+        foreach (var renderer in renderers)
+        {
+            if (!renderer)
+                continue;
+
+            var state = new RendererState(renderer);
+            rendererStates.Add(state);
+        }
+
+        isInitialized = true;
+    }
+
+    private void ApplyHighlight(bool highlighted, Color color, float emissionMultiplier)
+    {
+        if (rendererStates.Count == 0)
+            return;
+
+        foreach (var state in rendererStates)
+        {
+            state.ApplyHighlight(highlighted, color, emissionMultiplier, colorBlend);
+        }
+    }
+
+    private sealed class RendererState
+    {
+        public readonly Renderer Renderer;
+        public readonly MaterialPropertyBlock Block;
+        public readonly bool HasEmission;
+        public readonly Color BaseEmission;
+        public readonly bool HasColorProperty;
+        public readonly int ColorPropertyId;
+        public readonly Color BaseColor;
+
+        public RendererState(Renderer renderer)
+        {
+            Renderer = renderer;
+            Block = new MaterialPropertyBlock();
+            renderer.GetPropertyBlock(Block);
+
+            if (renderer.sharedMaterial && renderer.sharedMaterial.HasProperty(EmissionColorId))
+            {
+                HasEmission = true;
+                BaseEmission = renderer.sharedMaterial.GetColor(EmissionColorId);
+            }
+            else
+            {
+                HasEmission = false;
+                BaseEmission = Color.black;
+            }
+
+            if (renderer.sharedMaterial && renderer.sharedMaterial.HasProperty(BaseColorId))
+            {
+                HasColorProperty = true;
+                ColorPropertyId = BaseColorId;
+                BaseColor = renderer.sharedMaterial.GetColor(BaseColorId);
+            }
+            else if (renderer.sharedMaterial && renderer.sharedMaterial.HasProperty(ColorId))
+            {
+                HasColorProperty = true;
+                ColorPropertyId = ColorId;
+                BaseColor = renderer.sharedMaterial.GetColor(ColorId);
+            }
+            else
+            {
+                HasColorProperty = false;
+                ColorPropertyId = -1;
+                BaseColor = Color.white;
+            }
+        }
+
+        public void ApplyHighlight(bool highlighted, Color color, float emissionMultiplier, float blend)
+        {
+            if (Renderer == null)
+                return;
+
+            Renderer.GetPropertyBlock(Block);
+
+            if (HasEmission)
+            {
+                var emission = highlighted
+                    ? BaseEmission + color * Mathf.Max(0f, emissionMultiplier)
+                    : BaseEmission;
+
+                Block.SetColor(EmissionColorId, emission);
+
+                if (highlighted)
+                    Renderer.EnableKeyword("_EMISSION");
+                else if (BaseEmission.maxColorComponent <= 0f)
+                    Renderer.DisableKeyword("_EMISSION");
+            }
+
+            if (HasColorProperty)
+            {
+                var targetColor = highlighted
+                    ? Color.Lerp(BaseColor, color, Mathf.Clamp01(blend))
+                    : BaseColor;
+
+                Block.SetColor(ColorPropertyId, targetColor);
+            }
+
+            Renderer.SetPropertyBlock(Block);
+            Renderer.UpdateGIMaterials();
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Gameplay/InteractableHighlighter.cs.meta
+++ b/Assets/_Project/Scripts/Gameplay/InteractableHighlighter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eacc351d4d1642e7b8be7f84c7411093
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add an `InteractableHighlighter` component to boost emission/tint on highlighted meshes
- extend `PlayerInteraction` to track the current interaction target, trigger highlights, and zoom the camera onto aliens
- clear the focus state when interactions end so zoom and highlight return to normal

## Testing
- not run (Unity editor unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ee55e7b39483308fefd55360021be3