### PR TITLE
Add emotion-specific dialogue bubble variants

### DIFF
--- a/Assets/_Project/Scripts/Gameplay/Alien/Alien.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/Alien.cs
@@ -344,7 +344,7 @@ public class Alien : MonoBehaviour, IInteraction
         if (!_dialogueBubble || string.IsNullOrWhiteSpace(emojiLine) || duration <= 0f)
             return;
 
-        _dialogueBubble.ShowFor(emojiLine, duration);
+        _dialogueBubble.ShowFor(Emotion, emojiLine, duration);
     }
 
     private void HandleInteractionRule(InterractionRule rule, Behavior channel, Emotion playerEmotion, bool allowQuestProgress = true)

--- a/Assets/_Project/Scripts/Gameplay/Alien/DialogueBubble.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/DialogueBubble.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using NaughtyAttributes;
 using TMPro;
 using UnityEngine;
@@ -11,22 +13,46 @@ public sealed class DialogueBubble : MonoBehaviour
     private TextMeshProUGUI label;
 
     [SerializeField]
+    private EmotionBubbleSettings[] emotionSpecificBubbles;
+
+    [SerializeField]
     private bool lookAtCamera = true;
 
     [SerializeField, ShowIf(nameof(lookAtCamera))]
     private Camera targetCamera;
 
     private float remainingTime;
+    private readonly Dictionary<Emotion, BubbleInfo> bubbleLookup = new();
+    private readonly List<GameObject> allBubbles = new();
+    private BubbleInfo defaultBubble;
+    private BubbleInfo activeBubble;
+
+    [Serializable]
+    private struct EmotionBubbleSettings
+    {
+        public Emotion emotion;
+        public GameObject bubbleGameObject;
+        public TextMeshProUGUI label;
+    }
+
+    private struct BubbleInfo
+    {
+        public GameObject BubbleObject;
+        public TextMeshProUGUI Label;
+
+        public bool IsValid => BubbleObject != null;
+    }
 
     private void Awake()
     {
         targetCamera = Camera.main;
+        CacheBubbles();
         Hide();
     }
 
     private void Update()
     {
-        if (!bubbleGameObject || !bubbleGameObject.activeSelf)
+        if (!activeBubble.BubbleObject || !activeBubble.BubbleObject.activeSelf)
             return;
 
         if (remainingTime <= 0f)
@@ -51,26 +77,108 @@ public sealed class DialogueBubble : MonoBehaviour
         transform.LookAt(transform.position + forward, up);
     }
 
-    public void ShowFor(string emojiLine, float duration)
+    public void ShowFor(Emotion emotion, string emojiLine, float duration)
     {
         if (string.IsNullOrEmpty(emojiLine) || duration <= 0f)
             return;
 
-        if (label)
-            label.text = emojiLine;
+        var bubble = GetBubbleFor(emotion);
+        if (!bubble.IsValid)
+            return;
 
-        if (bubbleGameObject)
-            bubbleGameObject.SetActive(true);
+        if (activeBubble.BubbleObject && activeBubble.BubbleObject != bubble.BubbleObject)
+            activeBubble.BubbleObject.SetActive(false);
+
+        activeBubble = bubble;
+
+        if (!activeBubble.Label && activeBubble.BubbleObject)
+        {
+            activeBubble.Label = activeBubble.BubbleObject.GetComponentInChildren<TextMeshProUGUI>(true);
+            UpdateLookupLabel(emotion, activeBubble);
+        }
+
+        if (!activeBubble.Label && defaultBubble.Label)
+            activeBubble.Label = defaultBubble.Label;
+
+        if (activeBubble.Label)
+            activeBubble.Label.text = emojiLine;
+
+        activeBubble.BubbleObject.SetActive(true);
 
         remainingTime = duration;
     }
 
     private void Hide()
     {
-        if (bubbleGameObject)
+        foreach (var bubble in allBubbles)
         {
-            bubbleGameObject.SetActive(false);
+            if (bubble)
+                bubble.SetActive(false);
         }
+        activeBubble = default;
         remainingTime = 0f;
+    }
+
+    private void CacheBubbles()
+    {
+        bubbleLookup.Clear();
+        allBubbles.Clear();
+
+        defaultBubble = CreateBubbleInfo(bubbleGameObject, label);
+        if (defaultBubble.BubbleObject)
+        {
+            allBubbles.Add(defaultBubble.BubbleObject);
+            if (!defaultBubble.Label)
+            {
+                defaultBubble.Label = defaultBubble.BubbleObject.GetComponentInChildren<TextMeshProUGUI>(true);
+            }
+        }
+
+        if (emotionSpecificBubbles == null)
+            return;
+
+        foreach (var setting in emotionSpecificBubbles)
+        {
+            if (!setting.bubbleGameObject)
+                continue;
+
+            var info = CreateBubbleInfo(setting.bubbleGameObject, setting.label);
+
+            if (!info.Label)
+                info.Label = info.BubbleObject.GetComponentInChildren<TextMeshProUGUI>(true);
+
+            bubbleLookup[setting.emotion] = info;
+            allBubbles.Add(info.BubbleObject);
+        }
+    }
+
+    private BubbleInfo GetBubbleFor(Emotion emotion)
+    {
+        if (bubbleLookup.TryGetValue(emotion, out var info))
+        {
+            return info;
+        }
+
+        if (defaultBubble.IsValid)
+            return defaultBubble;
+
+        return new BubbleInfo();
+    }
+
+    private void UpdateLookupLabel(Emotion emotion, BubbleInfo info)
+    {
+        if (bubbleLookup.ContainsKey(emotion))
+            bubbleLookup[emotion] = info;
+        else
+            defaultBubble = info;
+    }
+
+    private static BubbleInfo CreateBubbleInfo(GameObject bubble, TextMeshProUGUI bubbleLabel)
+    {
+        return new BubbleInfo
+        {
+            BubbleObject = bubble,
+            Label = bubbleLabel
+        };
     }
 }

--- a/Assets/_Project/Scripts/Gameplay/Player/PlayerInterraction.cs
+++ b/Assets/_Project/Scripts/Gameplay/Player/PlayerInterraction.cs
@@ -211,13 +211,13 @@ public class PlayerInteraction : MonoBehaviour
         for (var i = 0; i < count; i++)
         {
             var collider = overlap[i];
-            if (collider == null || !collider.gameObject.activeInHierarchy)
+            if (!collider || !collider.gameObject.activeInHierarchy)
             {
                 continue;
             }
 
             var holdable = collider.GetComponentInParent<HoldableItem>();
-            if (holdable == null || !holdable.CanBePicked || holdable == heldItem)
+            if (!holdable || !holdable.CanBePicked || holdable == heldItem)
             {
                 continue;
             }
@@ -230,19 +230,17 @@ public class PlayerInteraction : MonoBehaviour
             }
         }
 
-        if (bestCandidate == null)
-        {
+        if (!bestCandidate)
             return;
-        }
 
-        if (heldItem != null)
+        if (heldItem)
         {
             var velocity = dropForwardSpeed > 0f ? transform.forward * dropForwardSpeed : Vector3.zero;
             heldItem.Drop(velocity);
             heldItem = null;
         }
 
-        bestCandidate.Pick(handSocket != null ? handSocket : transform);
+        bestCandidate.Pick(handSocket ? handSocket : transform);
         heldItem = bestCandidate;
         heldItemId = heldItem.ItemId;
         Debug.Log($"{LogPrefix} Objet '{heldItem.name}' ramassé (ID: {heldItemId}).");
@@ -250,7 +248,7 @@ public class PlayerInteraction : MonoBehaviour
 
     public void DropItem(bool destroyItem = false)
     {
-        if (heldItem == null)
+        if (!heldItem)
         {
             Debug.Log($"{LogPrefix} Aucun objet à déposer.");
             return;
@@ -260,16 +258,18 @@ public class PlayerInteraction : MonoBehaviour
         {
             Destroy(heldItem.gameObject);
             Debug.Log($"{LogPrefix} Objet '{heldItemId}' détruit.");
+            
             heldItem = null;
             heldItemId = null;
+            
             return;
         }
 
-        var origin = aimZone != null ? aimZone : transform;
+        var origin = aimZone ? aimZone : transform;
         var alien = TargetingUtil.FindAlienInFront(origin, interactRadius, interactHalfFov, interactMask);
 
         var gaveItem = false;
-        if (alien != null && alien.IsWithinReceiveRadius(origin.position))
+        if (alien && alien.IsWithinReceiveRadius(origin.position))
         {
             gaveItem = alien.TryReceiveItem(heldItemId);
             Debug.Log($"{LogPrefix} Don de '{heldItemId}' à '{alien.name}' → succès={gaveItem}.");
@@ -308,7 +308,7 @@ public class PlayerInteraction : MonoBehaviour
 
     private void ShowComboFeedback(Emotion emotion, Behavior behavior)
     {
-        if (comboBubble == null || emotion == Emotion.None || behavior == Behavior.None)
+        if (!comboBubble || emotion == Emotion.None || behavior == Behavior.None)
         {
             return;
         }
@@ -326,14 +326,15 @@ public class PlayerInteraction : MonoBehaviour
         if (comboLookup.TryGetValue(key, out var definition) && !string.IsNullOrWhiteSpace(definition.Symbols))
         {
             var duration = definition.Duration > 0f ? definition.Duration : defaultComboBubbleDuration;
-            comboBubble.Show(definition.Symbols, duration);
+            comboBubble.Show(definition.Emotion, definition.Symbols, duration);
+
             return;
         }
 
         if (DefaultBehaviorSymbols.TryGetValue(behavior, out var behaviorSymbol) &&
             DefaultEmotionSymbols.TryGetValue(emotion, out var emotionSymbol))
         {
-            comboBubble.Show(behaviorSymbol + emotionSymbol, defaultComboBubbleDuration);
+            comboBubble.Show(emotion, behaviorSymbol + emotionSymbol, defaultComboBubbleDuration);
         }
         else
         {

--- a/UserSettings/Layouts/CurrentMaximizeLayout.dwlt
+++ b/UserSettings/Layouts/CurrentMaximizeLayout.dwlt
@@ -24,7 +24,7 @@ MonoBehaviour:
   m_MinSize: {x: 300, y: 100}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
-  controlID: 26321
+  controlID: 1079
   draggingID: 0
 --- !u!114 &2
 MonoBehaviour:
@@ -151,7 +151,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 100}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 1
-  controlID: 26292
+  controlID: 1026
   draggingID: 0
 --- !u!114 &4
 MonoBehaviour:
@@ -177,7 +177,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 50}
   m_MaxSize: {x: 16192, y: 8096}
   vertical: 0
-  controlID: 26245
+  controlID: 1010
   draggingID: 0
 --- !u!114 &5
 MonoBehaviour:
@@ -246,7 +246,7 @@ MonoBehaviour:
       scrollPos: {x: 0, y: 0}
       m_SelectedIDs: 
       m_LastClickedID: 0
-      m_ExpandedIDs: 70b1fefffcd3ffff2ce5ffff54f3ffff92f5ffff0cfbffffd0d10000f0d3000084d5000050dd000000e00000
+      m_ExpandedIDs: 38e0ffff3ef6ffff0cfbffff08ce0000dcdc0000
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 
@@ -885,15 +885,15 @@ MonoBehaviour:
   m_OverrideSceneCullingMask: 6917529027641081856
   m_SceneIsLit: 1
   m_SceneLighting: 1
-  m_2DMode: 1
+  m_2DMode: 0
   m_isRotationLocked: 0
   m_PlayAudio: 0
   m_AudioPlay: 0
   m_DebugDrawModesUseInteractiveLightBakingData: 0
   m_Position:
-    m_Target: {x: 1087.4116, y: 577.7867, z: -32.183395}
+    m_Target: {x: -0.025606632, y: -0.48897886, z: -19.714182}
     speed: 2
-    m_Value: {x: 1087.4116, y: 577.7867, z: -32.183395}
+    m_Value: {x: -0.025606632, y: -0.48897886, z: -19.714182}
   m_RenderMode: 0
   m_CameraMode:
     drawMode: 0
@@ -921,17 +921,17 @@ MonoBehaviour:
       m_Size: {x: 0, y: 0}
     yGrid:
       m_Fade:
-        m_Target: 0
+        m_Target: 1
         speed: 2
-        m_Value: 0
+        m_Value: 1
       m_Color: {r: 0.5, g: 0.5, b: 0.5, a: 0.4}
       m_Pivot: {x: 0, y: 0, z: 0}
       m_Size: {x: 1, y: 1}
     zGrid:
       m_Fade:
-        m_Target: 1
+        m_Target: 0
         speed: 2
-        m_Value: 1
+        m_Value: 0
       m_Color: {r: 0.5, g: 0.5, b: 0.5, a: 0.4}
       m_Pivot: {x: 0, y: 0, z: 0}
       m_Size: {x: 1, y: 1}
@@ -939,17 +939,17 @@ MonoBehaviour:
     m_GridAxis: 1
     m_gridOpacity: 0.5
   m_Rotation:
-    m_Target: {x: 0, y: 0, z: 0, w: 1}
+    m_Target: {x: -0.025657263, y: 0.9417786, z: -0.32701898, w: -0.07389118}
     speed: 2
-    m_Value: {x: 0, y: 0, z: 0, w: 1}
+    m_Value: {x: -0.02565718, y: 0.94177556, z: -0.32701793, w: -0.07389094}
   m_Size:
-    m_Target: 596.1347
+    m_Target: 4.8826594
     speed: 2
-    m_Value: 596.1347
+    m_Value: 4.8826594
   m_Ortho:
-    m_Target: 1
+    m_Target: 0
     speed: 2
-    m_Value: 1
+    m_Value: 0
   m_CameraSettings:
     m_Speed: 1
     m_SpeedNormalized: 0.5
@@ -989,7 +989,7 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 1
   m_Script: {fileID: 12006, guid: 0000000000000000e000000000000000, type: 0}
-  m_Name: ConsoleWindow
+  m_Name: ProjectBrowser
   m_EditorClassIdentifier: 
   m_Children: []
   m_Position:
@@ -998,14 +998,14 @@ MonoBehaviour:
     y: 502.4
     width: 1110.4
     height: 310.4
-  m_MinSize: {x: 101, y: 126}
-  m_MaxSize: {x: 4001, y: 4026}
-  m_ActualView: {fileID: 11}
+  m_MinSize: {x: 231, y: 276}
+  m_MaxSize: {x: 10001, y: 10026}
+  m_ActualView: {fileID: 10}
   m_Panes:
   - {fileID: 10}
   - {fileID: 11}
-  m_Selected: 1
-  m_LastSelected: 0
+  m_Selected: 0
+  m_LastSelected: 1
 --- !u!114 &10
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -1053,7 +1053,7 @@ MonoBehaviour:
     m_SkipHidden: 0
     m_SearchArea: 1
     m_Folders:
-    - Assets/Travis Game Assets/Hit Impact Effects/Demo Scene/Scripts
+    - Assets/_Project/Scripts/Gameplay/Alien/SO/Alien1(Labubu enjoyer)
     m_Globs: []
     m_ProductIds: 
     m_AnyWithAssetOrigin: 0
@@ -1063,16 +1063,16 @@ MonoBehaviour:
   m_ViewMode: 1
   m_StartGridSize: 64
   m_LastFolders:
-  - Assets/Travis Game Assets/Hit Impact Effects/Demo Scene/Scripts
+  - Assets/_Project/Scripts/Gameplay/Alien/SO/Alien1(Labubu enjoyer)
   m_LastFoldersGridSize: -1
   m_LastProjectPath: C:\Apps\Unity\Synaptik
   m_LockTracker:
     m_IsLocked: 0
   m_FolderTreeState:
     scrollPos: {x: 0, y: 79}
-    m_SelectedIDs: 40840100
-    m_LastClickedID: 99392
-    m_ExpandedIDs: 00000000b0cc000000ca9a3bffffff7f
+    m_SelectedIDs: 1ce10000
+    m_LastClickedID: 57628
+    m_ExpandedIDs: 0000000010cd000064cd0000b4cd0000b6cd0000c6cd000018e1000000ca9a3bffffff7f
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -1101,7 +1101,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: 00000000b0cc000000ca9a3bffffff7f
+    m_ExpandedIDs: 0000000010cd000000ca9a3bffffff7f
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -1127,9 +1127,9 @@ MonoBehaviour:
       m_Icon: {fileID: 0}
       m_ResourceFile: 
   m_ListAreaState:
-    m_SelectedInstanceIDs: fcd3ffff
-    m_LastClickedInstanceID: -11268
-    m_HadKeyboardFocusLastEvent: 0
+    m_SelectedInstanceIDs: c2df0000e2de00000ee00000
+    m_LastClickedInstanceID: 57282
+    m_HadKeyboardFocusLastEvent: 1
     m_ExpandedInstanceIDs: c6230000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
@@ -1214,8 +1214,8 @@ MonoBehaviour:
     y: 0
     width: 425.59998
     height: 812.8
-  m_MinSize: {x: 275, y: 50}
-  m_MaxSize: {x: 4000, y: 4000}
+  m_MinSize: {x: 276, y: 76}
+  m_MaxSize: {x: 4001, y: 4026}
   m_ActualView: {fileID: 13}
   m_Panes:
   - {fileID: 13}
@@ -1263,8 +1263,8 @@ MonoBehaviour:
     m_CachedPref: -160
     m_ControlHash: -371814159
     m_PrefName: Preview_InspectorPreview
-  m_LastInspectedObjectInstanceID: -7572
-  m_LastVerticalScrollValue: 0
+  m_LastInspectedObjectInstanceID: 57058
+  m_LastVerticalScrollValue: 382.39996
   m_GlobalObjectId: 
   m_InspectorMode: 0
   m_LockTracker:


### PR DESCRIPTION
## Summary
- extend DialogueBubble to support emotion-specific bubble prefabs and labels
- ensure alien dialogues display the bubble variant that matches the alien's current emotion

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68ef59a6693c83309c479ff3d229a8a3