### PR TITLE
Add emotion-based color feedback to the player

### DIFF
--- a/Assets/_Project/Prefabs/Entities/Player.prefab
+++ b/Assets/_Project/Prefabs/Entities/Player.prefab
@@ -47,6 +47,7 @@ GameObject:
   - component: {fileID: 4174637969976801663}
   - component: {fileID: 8317182544908626716}
   - component: {fileID: 1346494414045638242}
+  - component: {fileID: 7968921228244856452}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -271,3 +272,28 @@ MonoBehaviour:
   backgroundColor: {r: 1, g: 1, b: 1, a: 0.4}
   textColor: {r: 0, g: 0, b: 0, a: 1}
   fontAsset: {fileID: 11400000, guid: 3944eaaf70beffa4097d8c293604125e, type: 2}
+--- !u!114 &7968921228244856452
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6717372861038130110}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 92ede64c5bd349f391e90bf1870c2ef7, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  emotionRenderers:
+  - {fileID: 8033691732964566090}
+  defaultColor: {r: 1, g: 1, b: 1, a: 1}
+  emotionColors:
+  - emotion: 1
+    color: {r: 0.9411765, g: 0.3254902, b: 0.3254902, a: 1}
+  - emotion: 2
+    color: {r: 1, g: 0.8666667, b: 0.3803922, a: 1}
+  - emotion: 3
+    color: {r: 0.49803922, g: 0.8352941, b: 0.3647059, a: 1}
+  - emotion: 4
+    color: {r: 0.05882353, g: 0.7529412, b: 0.87058824, a: 1}
+  colorFadeDuration: 0.3

--- a/Assets/_Project/Scripts/Gameplay/Player/PlayerEmotionVisuals.cs
+++ b/Assets/_Project/Scripts/Gameplay/Player/PlayerEmotionVisuals.cs
@@ -1,0 +1,268 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[RequireComponent(typeof(Renderer))]
+public sealed class PlayerEmotionVisuals : MonoBehaviour
+{
+    [Header("Renderers")] 
+    [SerializeField]
+    private Renderer[] emotionRenderers = Array.Empty<Renderer>();
+
+    [Header("Colors")] 
+    [SerializeField]
+    private Color defaultColor = Color.white;
+
+    [SerializeField]
+    private List<EmotionColorSetting> emotionColors = new()
+    {
+        new EmotionColorSetting
+        {
+            emotion = Emotion.Anger,
+            color = new Color(240f / 255f, 83f / 255f, 83f / 255f)
+        },
+        new EmotionColorSetting
+        {
+            emotion = Emotion.Curious,
+            color = new Color(127f / 255f, 213f / 255f, 93f / 255f)
+        },
+        new EmotionColorSetting
+        {
+            emotion = Emotion.Fearful,
+            color = new Color(15f / 255f, 192f / 255f, 222f / 255f)
+        },
+        new EmotionColorSetting
+        {
+            emotion = Emotion.Friendly,
+            color = new Color(255f / 255f, 221f / 255f, 97f / 255f)
+        }
+    };
+
+    [SerializeField, Min(0f)]
+    private float colorFadeDuration = 0.3f;
+
+    private readonly List<Emotion> activeEmotions = new();
+    private readonly Dictionary<Emotion, Color> emotionColorLookup = new();
+
+    private InputsDetection cachedInputsDetection;
+    private bool isSubscribed;
+
+    private MaterialPropertyBlock propertyBlock;
+    private Coroutine colorFadeCoroutine;
+
+    private static readonly int BaseColorId = Shader.PropertyToID("_BaseColor");
+    private static readonly int ColorId = Shader.PropertyToID("_Color");
+
+    [Serializable]
+    private struct EmotionColorSetting
+    {
+        public Emotion emotion;
+        public Color color;
+    }
+
+    private void Reset()
+    {
+        if (emotionRenderers == null || emotionRenderers.Length == 0)
+        {
+            var renderer = GetComponent<Renderer>();
+            if (renderer)
+            {
+                emotionRenderers = new[] { renderer };
+            }
+        }
+    }
+
+    private void Awake()
+    {
+        CacheEmotionColors();
+        EnsureRenderers();
+        ApplyColorImmediate(defaultColor);
+    }
+
+    private void OnEnable()
+    {
+        TrySubscribe();
+        ApplyColorImmediate(GetColorForCurrentEmotion());
+    }
+
+    private void Start()
+    {
+        TrySubscribe();
+    }
+
+    private void OnDisable()
+    {
+        TryUnsubscribe();
+    }
+
+    private void OnDestroy()
+    {
+        TryUnsubscribe();
+    }
+
+    private void TrySubscribe()
+    {
+        if (isSubscribed)
+            return;
+
+        var instance = InputsDetection.Instance;
+        if (!instance)
+            return;
+
+        instance.OnEmotion += HandleEmotionInput;
+        cachedInputsDetection = instance;
+        isSubscribed = true;
+    }
+
+    private void TryUnsubscribe()
+    {
+        if (!isSubscribed)
+            return;
+
+        if (cachedInputsDetection)
+        {
+            cachedInputsDetection.OnEmotion -= HandleEmotionInput;
+        }
+
+        cachedInputsDetection = null;
+        isSubscribed = false;
+    }
+
+    private void HandleEmotionInput(Emotion emotion, bool keyReleased)
+    {
+        if (emotion == Emotion.None)
+            return;
+
+        if (!keyReleased)
+        {
+            activeEmotions.Remove(emotion);
+            activeEmotions.Add(emotion);
+        }
+        else
+        {
+            activeEmotions.RemoveAll(e => e == emotion);
+        }
+
+        var targetColor = GetColorForCurrentEmotion();
+        FadeToColor(targetColor);
+    }
+
+    private Color GetColorForCurrentEmotion()
+    {
+        if (activeEmotions.Count == 0)
+            return defaultColor;
+
+        var latestEmotion = activeEmotions[activeEmotions.Count - 1];
+        if (emotionColorLookup.TryGetValue(latestEmotion, out var color))
+        {
+            return color;
+        }
+
+        return defaultColor;
+    }
+
+    private void CacheEmotionColors()
+    {
+        emotionColorLookup.Clear();
+
+        if (emotionColors == null)
+            return;
+
+        for (var i = 0; i < emotionColors.Count; i++)
+        {
+            var setting = emotionColors[i];
+            if (setting.emotion == Emotion.None)
+                continue;
+
+            emotionColorLookup[setting.emotion] = setting.color;
+        }
+    }
+
+    private void EnsureRenderers()
+    {
+        if (emotionRenderers != null && emotionRenderers.Length > 0)
+            return;
+
+        var renderer = GetComponent<Renderer>();
+        if (renderer)
+        {
+            emotionRenderers = new[] { renderer };
+        }
+    }
+
+    private void FadeToColor(Color targetColor)
+    {
+        if (emotionRenderers == null || emotionRenderers.Length == 0)
+            return;
+
+        if (propertyBlock == null)
+            propertyBlock = new MaterialPropertyBlock();
+
+        if (colorFadeCoroutine != null)
+            StopCoroutine(colorFadeCoroutine);
+
+        if (colorFadeDuration <= 0f)
+        {
+            ApplyColorImmediate(targetColor);
+            return;
+        }
+
+        colorFadeCoroutine = StartCoroutine(FadeRoutine(targetColor));
+    }
+
+    private IEnumerator FadeRoutine(Color targetColor)
+    {
+        var startColor = GetCurrentRendererColor();
+        float elapsed = 0f;
+
+        while (elapsed < colorFadeDuration)
+        {
+            elapsed += Time.deltaTime;
+            float t = Mathf.Clamp01(elapsed / colorFadeDuration);
+            var lerped = Color.Lerp(startColor, targetColor, Mathf.SmoothStep(0f, 1f, t));
+            ApplyColorImmediate(lerped);
+            yield return null;
+        }
+
+        ApplyColorImmediate(targetColor);
+        colorFadeCoroutine = null;
+    }
+
+    private Color GetCurrentRendererColor()
+    {
+        if (emotionRenderers == null || emotionRenderers.Length == 0)
+            return defaultColor;
+
+        if (propertyBlock == null)
+            propertyBlock = new MaterialPropertyBlock();
+
+        var renderer = emotionRenderers[0];
+        if (!renderer)
+            return defaultColor;
+
+        renderer.GetPropertyBlock(propertyBlock);
+        return propertyBlock.GetColor(BaseColorId);
+    }
+
+    private void ApplyColorImmediate(Color color)
+    {
+        if (emotionRenderers == null || emotionRenderers.Length == 0)
+            return;
+
+        if (propertyBlock == null)
+            propertyBlock = new MaterialPropertyBlock();
+
+        for (var i = 0; i < emotionRenderers.Length; i++)
+        {
+            var renderer = emotionRenderers[i];
+            if (!renderer)
+                continue;
+
+            renderer.GetPropertyBlock(propertyBlock);
+            propertyBlock.SetColor(BaseColorId, color);
+            propertyBlock.SetColor(ColorId, color);
+            renderer.SetPropertyBlock(propertyBlock);
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Gameplay/Player/PlayerEmotionVisuals.cs.meta
+++ b/Assets/_Project/Scripts/Gameplay/Player/PlayerEmotionVisuals.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 92ede64c5bd349f391e90bf1870c2ef7

--- a/UserSettings/Layouts/CurrentMaximizeLayout.dwlt
+++ b/UserSettings/Layouts/CurrentMaximizeLayout.dwlt
@@ -24,7 +24,7 @@ MonoBehaviour:
   m_MinSize: {x: 300, y: 100}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
-  controlID: 1079
+  controlID: 3324
   draggingID: 0
 --- !u!114 &2
 MonoBehaviour:
@@ -151,7 +151,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 100}
   m_MaxSize: {x: 16192, y: 16192}
   vertical: 1
-  controlID: 1026
+  controlID: 3265
   draggingID: 0
 --- !u!114 &4
 MonoBehaviour:
@@ -177,7 +177,7 @@ MonoBehaviour:
   m_MinSize: {x: 200, y: 50}
   m_MaxSize: {x: 16192, y: 8096}
   vertical: 0
-  controlID: 1010
+  controlID: 3231
   draggingID: 0
 --- !u!114 &5
 MonoBehaviour:
@@ -246,7 +246,7 @@ MonoBehaviour:
       scrollPos: {x: 0, y: 0}
       m_SelectedIDs: 
       m_LastClickedID: 0
-      m_ExpandedIDs: 38e0ffff3ef6ffff0cfbffff08ce0000dcdc0000
+      m_ExpandedIDs: 20b0ffff38e0ffff3ef6ffff0cfbffff08ce0000dcdc0000
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 
@@ -891,9 +891,9 @@ MonoBehaviour:
   m_AudioPlay: 0
   m_DebugDrawModesUseInteractiveLightBakingData: 0
   m_Position:
-    m_Target: {x: -0.025606632, y: -0.48897886, z: -19.714182}
+    m_Target: {x: -7.1649866, y: 0.5925088, z: -13.2354555}
     speed: 2
-    m_Value: {x: -0.025606632, y: -0.48897886, z: -19.714182}
+    m_Value: {x: -7.1649866, y: 0.5925088, z: -13.2354555}
   m_RenderMode: 0
   m_CameraMode:
     drawMode: 0
@@ -939,9 +939,9 @@ MonoBehaviour:
     m_GridAxis: 1
     m_gridOpacity: 0.5
   m_Rotation:
-    m_Target: {x: -0.025657263, y: 0.9417786, z: -0.32701898, w: -0.07389118}
+    m_Target: {x: -0.1740381, y: 0.72497934, z: -0.1983113, w: -0.636239}
     speed: 2
-    m_Value: {x: -0.02565718, y: 0.94177556, z: -0.32701793, w: -0.07389094}
+    m_Value: {x: -0.17403708, y: 0.7249751, z: -0.19831014, w: -0.6362353}
   m_Size:
     m_Target: 4.8826594
     speed: 2
@@ -1053,7 +1053,7 @@ MonoBehaviour:
     m_SkipHidden: 0
     m_SearchArea: 1
     m_Folders:
-    - Assets/_Project/Scripts/Gameplay/Alien/SO/Alien1(Labubu enjoyer)
+    - Assets/_Project/Scripts/Gameplay/Player
     m_Globs: []
     m_ProductIds: 
     m_AnyWithAssetOrigin: 0
@@ -1063,15 +1063,15 @@ MonoBehaviour:
   m_ViewMode: 1
   m_StartGridSize: 64
   m_LastFolders:
-  - Assets/_Project/Scripts/Gameplay/Alien/SO/Alien1(Labubu enjoyer)
+  - Assets/_Project/Scripts/Gameplay/Player
   m_LastFoldersGridSize: -1
   m_LastProjectPath: C:\Apps\Unity\Synaptik
   m_LockTracker:
     m_IsLocked: 0
   m_FolderTreeState:
-    scrollPos: {x: 0, y: 79}
-    m_SelectedIDs: 1ce10000
-    m_LastClickedID: 57628
+    scrollPos: {x: 0, y: 135.6}
+    m_SelectedIDs: b2cd0000
+    m_LastClickedID: 52658
     m_ExpandedIDs: 0000000010cd000064cd0000b4cd0000b6cd0000c6cd000018e1000000ca9a3bffffff7f
     m_RenameOverlay:
       m_UserAcceptedRename: 0
@@ -1127,8 +1127,8 @@ MonoBehaviour:
       m_Icon: {fileID: 0}
       m_ResourceFile: 
   m_ListAreaState:
-    m_SelectedInstanceIDs: c2df0000e2de00000ee00000
-    m_LastClickedInstanceID: 57282
+    m_SelectedInstanceIDs: 66f60000
+    m_LastClickedInstanceID: 63078
     m_HadKeyboardFocusLastEvent: 1
     m_ExpandedInstanceIDs: c6230000
     m_RenameOverlay:
@@ -1263,8 +1263,8 @@ MonoBehaviour:
     m_CachedPref: -160
     m_ControlHash: -371814159
     m_PrefName: Preview_InspectorPreview
-  m_LastInspectedObjectInstanceID: 57058
-  m_LastVerticalScrollValue: 382.39996
+  m_LastInspectedObjectInstanceID: 63078
+  m_LastVerticalScrollValue: 1034.3999
   m_GlobalObjectId: 
   m_InspectorMode: 0
   m_LockTracker:


### PR DESCRIPTION
## Summary
- add a PlayerEmotionVisuals component that listens to emotion inputs and fades the player mesh to the matching color
- wire the new component into the player prefab with the renderer reference and emotion palette

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68efb08ce9908330ab4e3c6c01107f05