### PR TITLE
Refactor quest system for modular triggers and events

### DIFF
--- a/Assets/_Project/Scripts/Gameplay/Alien/Alien.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/Alien.cs
@@ -109,18 +109,35 @@ public class Alien : MonoBehaviour, IInteraction
 
             if (quest.HasSteps && hasQuestId && !_questRuntimes.ContainsKey(quest.QuestId))
             {
-                _questRuntimes.Add(quest.QuestId, new AlienQuestRuntime(quest));
+                var runtime = new AlienQuestRuntime(quest, this);
+                _questRuntimes.Add(quest.QuestId, runtime);
+                QuestRuntimeRegistry.Register(runtime);
+                runtime.Initialize();
             }
         }
-        
-        GameManager.Instance.OnTaskEnd += OnAlienTaskEnd;
+
+        if (GameManager.Instance)
+        {
+            GameManager.Instance.OnTaskEnd += OnAlienTaskEnd;
+        }
     }
 
     private void OnDestroy()
     {
         if (AlienManager.Instance)
             AlienManager.Instance.UnregisterAlien(this);
-        GameManager.Instance.OnTaskEnd -= OnAlienTaskEnd;
+
+        if (GameManager.Instance)
+        {
+            GameManager.Instance.OnTaskEnd -= OnAlienTaskEnd;
+        }
+
+        foreach (var runtime in _questRuntimes.Values)
+        {
+            QuestRuntimeRegistry.Unregister(runtime);
+        }
+
+        _questRuntimes.Clear();
     }
     
     private void OnAlienTaskEnd(Mission mission, AlienDefinition alienDefinition)

--- a/Assets/_Project/Scripts/Gameplay/Alien/Quests/QuestRuntimeRegistry.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/Quests/QuestRuntimeRegistry.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Global registry exposing quest runtimes so that gameplay systems can raise triggers
+/// and observe lifecycle changes without tight coupling to alien components.
+/// </summary>
+public static class QuestRuntimeRegistry
+{
+    private static readonly Dictionary<string, AlienQuestRuntime> Runtimes = new();
+
+    /// <summary>
+    /// Raised when a quest step becomes active for a registered runtime.
+    /// </summary>
+    public static event System.Action<QuestStepEventArgs> StepActivated;
+
+    /// <summary>
+    /// Raised when a quest step completes successfully.
+    /// </summary>
+    public static event System.Action<QuestStepEventArgs> StepCompleted;
+
+    /// <summary>
+    /// Raised when a quest finishes. The <see cref="QuestStepEventArgs.HasStep"/> flag indicates
+    /// whether a specific step was responsible for completion.
+    /// </summary>
+    public static event System.Action<QuestStepEventArgs> QuestCompleted;
+
+    public static void Register(AlienQuestRuntime runtime)
+    {
+        if (runtime == null || string.IsNullOrWhiteSpace(runtime.QuestId))
+        {
+            return;
+        }
+
+        if (Runtimes.TryGetValue(runtime.QuestId, out var existing) && existing != runtime)
+        {
+            Debug.LogWarning($"[QuestRegistry] Overwriting existing runtime for quest '{runtime.QuestId}'.");
+        }
+
+        Runtimes[runtime.QuestId] = runtime;
+    }
+
+    public static void Unregister(AlienQuestRuntime runtime)
+    {
+        if (runtime == null || string.IsNullOrWhiteSpace(runtime.QuestId))
+        {
+            return;
+        }
+
+        if (Runtimes.TryGetValue(runtime.QuestId, out var existing) && existing == runtime)
+        {
+            Runtimes.Remove(runtime.QuestId);
+        }
+    }
+
+    public static bool RaiseTrigger(string questId, QuestTrigger trigger)
+    {
+        return RaiseTrigger(questId, null, trigger);
+    }
+
+    public static bool RaiseTrigger(string questId, string stepId, QuestTrigger trigger)
+    {
+        if (string.IsNullOrWhiteSpace(questId))
+        {
+            Debug.LogWarning($"[QuestRegistry] Tried to raise trigger without quest id. Trigger: {trigger}.");
+            return false;
+        }
+
+        if (!Runtimes.TryGetValue(questId, out var runtime))
+        {
+            Debug.LogWarning($"[QuestRegistry] No runtime registered for quest '{questId}'. Trigger: {trigger}.");
+            return false;
+        }
+
+        return runtime.TryHandleTrigger(stepId, trigger);
+    }
+
+    internal static void NotifyStepActivated(in QuestStepEventArgs args)
+    {
+        StepActivated?.Invoke(args);
+    }
+
+    internal static void NotifyStepCompleted(in QuestStepEventArgs args)
+    {
+        StepCompleted?.Invoke(args);
+    }
+
+    internal static void NotifyQuestCompleted(in QuestStepEventArgs args)
+    {
+        QuestCompleted?.Invoke(args);
+    }
+}

--- a/Assets/_Project/Scripts/Gameplay/Alien/Quests/QuestStepEventArgs.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/Quests/QuestStepEventArgs.cs
@@ -1,0 +1,23 @@
+using System;
+
+/// <summary>
+/// Event payload emitted when quest steps change state.
+/// </summary>
+public readonly struct QuestStepEventArgs
+{
+    public QuestStepEventArgs(AlienQuestRuntime runtime, QuestStep step, QuestTrigger? trigger = null)
+    {
+        Runtime = runtime ?? throw new ArgumentNullException(nameof(runtime));
+        Step = step;
+        Trigger = trigger;
+    }
+
+    public AlienQuestRuntime Runtime { get; }
+    public QuestStep Step { get; }
+    public QuestTrigger? Trigger { get; }
+
+    public string QuestId => Runtime.QuestId;
+    public string StepId => Step.StepId;
+    public Alien Owner => Runtime.Owner;
+    public bool HasStep => !string.IsNullOrWhiteSpace(Step.StepId);
+}

--- a/Assets/_Project/Scripts/Gameplay/Alien/Quests/QuestStepEvents.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/Quests/QuestStepEvents.cs
@@ -1,0 +1,70 @@
+using System;
+using UnityEngine;
+using UnityEngine.Events;
+
+/// <summary>
+/// Designer-friendly UnityEvents invoked when a quest step changes lifecycle states.
+/// Allows binding VFX, audio, UI, and other reactions without custom code.
+/// </summary>
+[Serializable]
+public sealed class QuestStepEvents
+{
+    [SerializeField]
+    private UnityEvent onStepActivated = new UnityEvent();
+
+    [SerializeField]
+    private UnityEvent onStepCompleted = new UnityEvent();
+
+    [SerializeField]
+    private UnityEvent onStepFailed = new UnityEvent();
+
+    public static QuestStepEvents Empty
+    {
+        get
+        {
+            _empty ??= new QuestStepEvents();
+            return _empty;
+        }
+    }
+
+    private static QuestStepEvents _empty;
+
+    public QuestStepEvents()
+    {
+        EnsureEvents();
+    }
+
+    /// <summary>
+    /// Invoked when the step becomes the active objective for the player.
+    /// </summary>
+    public void InvokeActivated()
+    {
+        EnsureEvents();
+        onStepActivated.Invoke();
+    }
+
+    /// <summary>
+    /// Invoked when the step successfully completes.
+    /// </summary>
+    public void InvokeCompleted()
+    {
+        EnsureEvents();
+        onStepCompleted.Invoke();
+    }
+
+    /// <summary>
+    /// Invoked when the step is failed or skipped.
+    /// </summary>
+    public void InvokeFailed()
+    {
+        EnsureEvents();
+        onStepFailed.Invoke();
+    }
+
+    private void EnsureEvents()
+    {
+        onStepActivated ??= new UnityEvent();
+        onStepCompleted ??= new UnityEvent();
+        onStepFailed ??= new UnityEvent();
+    }
+}

--- a/Assets/_Project/Scripts/Gameplay/Alien/Quests/QuestTrigger.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/Quests/QuestTrigger.cs
@@ -1,0 +1,54 @@
+/// <summary>
+/// Represents a gameplay event that can progress a quest step.
+/// </summary>
+public readonly struct QuestTrigger
+{
+    public QuestTrigger(string triggerId)
+    {
+        TriggerId = QuestTriggerUtility.NormalizeTriggerId(triggerId);
+        LegacyType = null;
+        Payload = null;
+    }
+
+    public QuestTrigger(string triggerId, object payload)
+    {
+        TriggerId = QuestTriggerUtility.NormalizeTriggerId(triggerId);
+        LegacyType = null;
+        Payload = payload;
+    }
+
+    public QuestTrigger(QuestStepType legacyType)
+    {
+        TriggerId = QuestTriggerUtility.GetDefaultTriggerId(legacyType);
+        LegacyType = legacyType;
+        Payload = null;
+    }
+
+    public QuestTrigger(string triggerId, QuestStepType? legacyType, object payload)
+    {
+        TriggerId = QuestTriggerUtility.NormalizeTriggerId(triggerId);
+        LegacyType = legacyType;
+        Payload = payload;
+    }
+
+    public string TriggerId { get; }
+    public QuestStepType? LegacyType { get; }
+    public object Payload { get; }
+
+    public bool IsEmpty => string.IsNullOrEmpty(TriggerId) && !LegacyType.HasValue;
+
+    public static QuestTrigger FromLegacy(QuestStepType legacyType)
+    {
+        return new QuestTrigger(QuestTriggerUtility.GetDefaultTriggerId(legacyType), legacyType, null);
+    }
+
+    public QuestTrigger WithPayload(object payload)
+    {
+        return new QuestTrigger(TriggerId, LegacyType, payload);
+    }
+
+    public override string ToString()
+    {
+        return $"TriggerId='{TriggerId}' LegacyType={(LegacyType.HasValue ? LegacyType.Value.ToString() : "<none>")}";
+    }
+}

--- a/Assets/_Project/Scripts/Gameplay/Alien/Quests/QuestTriggerUtility.cs
+++ b/Assets/_Project/Scripts/Gameplay/Alien/Quests/QuestTriggerUtility.cs
@@ -1,0 +1,43 @@
+using System;
+
+/// <summary>
+/// Helper utilities for normalising and comparing quest trigger identifiers.
+/// </summary>
+public static class QuestTriggerUtility
+{
+    /// <summary>
+    /// Normalises a trigger identifier for deterministic comparisons.
+    /// </summary>
+    public static string NormalizeTriggerId(string triggerId)
+    {
+        return string.IsNullOrWhiteSpace(triggerId)
+            ? string.Empty
+            : triggerId.Trim().ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Returns true when the provided candidate matches the normalised trigger id.
+    /// </summary>
+    public static bool EqualsTriggerIds(string normalizedTriggerId, string candidate)
+    {
+        if (string.IsNullOrEmpty(normalizedTriggerId))
+        {
+            return string.IsNullOrWhiteSpace(candidate);
+        }
+
+        return normalizedTriggerId == NormalizeTriggerId(candidate);
+    }
+
+    /// <summary>
+    /// Provides a default trigger identifier for legacy quest step types.
+    /// </summary>
+    public static string GetDefaultTriggerId(QuestStepType stepType)
+    {
+        return stepType switch
+        {
+            QuestStepType.Talk => "talk",
+            QuestStepType.GiveItem => "give_item",
+            _ => stepType.ToString().ToLowerInvariant()
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- allow quest steps to define custom trigger identifiers and designer-configurable lifecycle events
- refactor AlienQuestRuntime to drive triggers through a new QuestTrigger model and event dispatcher
- introduce QuestRuntimeRegistry so gameplay systems can raise triggers and observe quest lifecycle callbacks

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_e_68f3dc89ff488330a4706e3db192248d